### PR TITLE
Limit packaging extraneous files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "engines": {
     "node" : ">=4.2.0"
   },
+  "files": ["lib"],
   "dependencies": {
     "async": "^2.0.0-rc.6",
     "request": "^2.72.0"


### PR DESCRIPTION
By default `npm publish` includes all files and uploads them into the registry. This PR prevents files such as `.gitignore`, `travis.yml`, and the `test/` directory from being published.

You can test these changes without actually publishing by running `npm pack`.