### PR TITLE
Cluster level resources, for example, `k8.resourcequotas.get`

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -36,19 +36,24 @@ class Api {
       namespace: options.namespace
     });
 
-    // Default resources (e.g., api.replicationcontrollers.get...)
-    // TODO(sbw): This creates ambiguities in some cases. For example, with
-    // secrets: both /api/v1/secrets and /api/v1/namespaces/{namespace}/secrets
-    // are valid, so it's unclear what api.secrets refers to.
-    this._defaultNs.types.forEach(type => { this[type] = this._defaultNs[type] });
-
     //
     // Create resources that live at the root (e.g., /api/v1/nodes)
     //
     const genericTypes = [
       'componentstatuses',
+      'configmaps',
+      'endpoints',
+      'events',
+      'limitranges',
       'nodes',
-      'persistentvolumes'
+      'persistentvolumes',
+      'pods',
+      'podtemplates',
+      'replicationcontrollers',
+      'resourcequotas',
+      'secrets',
+      'serviceaccounts',
+      'services'
     ];
     for (const type of genericTypes) {
       this[type] = new BaseObject({

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -96,6 +96,25 @@ describe('lib.api', () => {
     });
   });
 
+  describe('.resourcequotas', () => {
+    beforeTesting('unit', () => {
+      nock(api.url)
+        .get('/api/v1/resourcequotas')
+        .reply(200, {
+          kind: 'ResourceQuotaList',
+          items: []
+        });
+    });
+
+    it('returns ResourceQuotaList', done => {
+      api.resourcequotas.get((err, results) => {
+        assume(err).is.falsy();
+        assume(results.kind).is.equal('ResourceQuotaList');
+        done();
+      });
+    });
+  });
+
   describe('.match', () => {
     beforeTesting('int', done => {
       api.wipe(err => {

--- a/test/objects.test.js
+++ b/test/objects.test.js
@@ -166,7 +166,7 @@ describe('objects', function () {
     });
 
     it('creates a ReplicationController', function (done) {
-      api.rc.post({ body: testReplicationController }, (err, result) => {
+      api.ns.rc.post({ body: testReplicationController }, (err, result) => {
         assume(err).is.falsy();
         assume(result.metadata.name).is.equal('test-rc');
         done();
@@ -178,7 +178,7 @@ describe('objects', function () {
     beforeTesting('int', done => {
       api.wipe(err => {
         assume(err).is.falsy();
-        api.rc.post({ body: testReplicationController }, done);
+        api.ns.rc.post({ body: testReplicationController }, done);
       });
     });
     beforeTesting('unit', () => {
@@ -187,7 +187,7 @@ describe('objects', function () {
         .reply(200, testReplicationController);
     });
     it('PUTs the new manifest', function (done) {
-      api.rc.put({ name: 'test-rc', body: testReplicationController }, (err, result) => {
+      api.ns.rc.put({ name: 'test-rc', body: testReplicationController }, (err, result) => {
         assume(err).is.falsy();
         assume(result.metadata.name).is.equal('test-rc');
         done();


### PR DESCRIPTION
This removes the default namespace shortcuts (e.g., `api.rc`) because they're
ambiguous with the cluster level resources.