### PR TITLE
Throw an Error if `rc.po.get` invoked without options and cb.

### DIFF
--- a/lib/replicationcontrollers.js
+++ b/lib/replicationcontrollers.js
@@ -29,6 +29,10 @@ class ReplicationControllerPods extends BaseObject {
    * @param {callback} cb - The callback that handles the response
    */
   get(options, cb) {
+    if (arguments.length < 2) {
+      throw new Error(
+        'GETing ReplicationController Pods requires options and cb arguments');
+    }
     this.rc.get(options, (rcErr, rc) => {
       if (rcErr) return cb(rcErr);
 

--- a/lib/replicationcontrollers.js
+++ b/lib/replicationcontrollers.js
@@ -31,7 +31,9 @@ class ReplicationControllerPods extends BaseObject {
   get(options, cb) {
     if (arguments.length < 2) {
       throw new Error(
-        'GETing ReplicationController Pods requires options and cb arguments');
+        'GETing ReplicationController Pods requires options and cb arguments. ' +
+        'Use api.namsepaces.pods.get if you want to get all Pods in a Namespace.'
+      );
     }
     this.rc.get(options, (rcErr, rc) => {
       if (rcErr) return cb(rcErr);

--- a/test/objects.test.js
+++ b/test/objects.test.js
@@ -128,6 +128,12 @@ describe('objects', function () {
         done();
       });
     });
+    only('unit', 'throws Error if missing options', function () {
+      function testFn() {
+        rcs().po.get(() => { throw Error('Should not reach'); });
+      }
+      assume(testFn).throws();
+    });
   });
 
   describe('.ReplicationControllers.delete', function () {


### PR DESCRIPTION
`rc.po.get` breaks usual pattern (if no options, get everything), because it's
not useful do that (users should use `po.get`), and we don't handle it in the
`rc.po.get` code. It's a programming mistake of `options` is missing, so throw
an Error.