### PR TITLE
test-integration: make timeout configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "jscs": "godaddy-js-style-jscs lib/ test/",
     "lint": "godaddy-js-style-lint lib/ test/",
     "test": "mocha",
-    "test-integration": "TESTING=int mocha -t 30000 test"
+    "test-integration": "TESTING=int mocha -t ${TIMEOUT:-30000} test"
   },
   "repository": "godaddy/kubernetes-client",
   "keywords": ["kubernetes", "kubectl", "containers"],

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -33,7 +33,10 @@ describe('lib.api', () => {
   describe('.ns', () => {
 
     beforeTesting('integration', done => {
-      api.ns.delete({ name: defaultName, timeout: 10000 }, () => done());
+      api.ns.delete({
+        name: defaultName,
+        timeout: common.defaultTimeout
+      }, () => done());
     });
     beforeTesting('unit', () => {
       const mockNamespace = {
@@ -64,7 +67,10 @@ describe('lib.api', () => {
           }}, next);
         },
         next => api.ns.get(defaultName, next),
-        next => api.ns.delete({ name: defaultName, timeout: 10000 }, next)
+        next => api.ns.delete({
+          name: defaultName,
+          timeout: common.defaultTimeout
+        }, next)
       ], (err, results) => {
         assume(err).is.falsy();
         const namespace = results[1];

--- a/test/common.js
+++ b/test/common.js
@@ -4,6 +4,7 @@
 const Api = require('../lib/api');
 
 const defaultName = process.env.NAMESPACE || 'integration-tests';
+const defaultTimeout = process.env.TIMEOUT || 30000;
 
 function testing(type) {
   const t = process.env.TESTING || 'unit';
@@ -37,7 +38,7 @@ if (testing('int')) {
     namespace: defaultName
   });
   api.wipe = function (cb) {
-    this.ns.delete({ name: defaultName, timeout: 30000 }, () => {
+    this.ns.delete({ name: defaultName, timeout: defaultTimeout }, err => {
       this.ns.post({ body: {
         kind: 'Namespace',
         metadata: {


### PR DESCRIPTION
The time it takes to remove a namespace seems highly variable. Provide an
environment variable to configure it:

`TIMEOUT=120000 NAMESPACE=integration-tests-sbw URL=https://my-cluster.com npm run test-integration`