### PR TITLE
Rename `Api` to `ApiGroup`

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -5,7 +5,7 @@ const aliasResources = require('./common').aliasResources;
 const BaseObject = require('./base');
 const Namespaces = require('./namespaces');
 
-class Api {
+class ApiGroup {
   /**
    * API object
    * @param {object} options - Options object
@@ -180,4 +180,4 @@ function ns(api) {
   return namespacer;
 }
 
-module.exports = Api;
+module.exports = ApiGroup;

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Api = require('./api');
+const ApiGroup = require('./api-group');
 
-class Core extends Api {
+class Core extends ApiGroup {
   constructor(options) {
     const genericTypes = [
       'componentstatuses',

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Api = require('./api');
+const ApiGroup = require('./api-group');
 
-class Extensions extends Api {
+class Extensions extends ApiGroup {
   constructor(options) {
     const genericTypes = [
       'daemonsets',

--- a/test/api-group.test.js
+++ b/test/api-group.test.js
@@ -29,7 +29,7 @@ function pod(name) {
   };
 }
 
-describe('lib.api', () => {
+describe('lib.api-group', () => {
   describe('.ns', () => {
 
     beforeTesting('integration', done => {


### PR DESCRIPTION
"Group" is terminology from: https://github.com/kubernetes/kubernetes/blob/master/docs/api.md