### PR TITLE
Ensure API for Kubernetes objects is consistent.

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -41,7 +41,8 @@ class ApiGroup {
     //
     for (const type of options.genericTypes) {
       this[type] = new BaseObject({
-        path: `${ this.path }/${ type }`,
+        name: type,
+        parentPath: this.path,
         api: this
       });
     }

--- a/lib/base.js
+++ b/lib/base.js
@@ -22,8 +22,10 @@ class BaseObject {
    * @param {string} options.path - Kubernetes resource path
    */
   constructor(options) {
+    this.name = options.name;
+    this.parentPath = options.parentPath;
     this.api = options.api;
-    this.path = options.path;
+    this.path = `${ options.parentPath }/${ options.name }`;
     this.qs = options.qs || {};
   }
 

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -18,19 +18,21 @@ class Namespaces extends BaseObject {
    */
   constructor(options) {
     super(Object.assign({
-      path: `${ options.parentPath }/namespaces`,
+      name: 'namespaces',
+      parentPath: options.parentPath,
       api: options.api
     }, options));
 
     this.namespace = options.namespace || 'default';
-    // Default resources.
+
     const resourceOptions = {
       api: this.api,
       parentPath: `${ this.path }/${ this.namespace }`
     };
-    this.replicationcontrollers = new ReplicationControllers(resourceOptions);
-    this.pods = new Pods(resourceOptions);
-
+    this.replicationcontrollers = new ReplicationControllers(
+      Object.assign({}, resourceOptions, { name: 'replicationcontrollers' }));
+    this.pods = new Pods(
+      Object.assign({}, resourceOptions, { name: 'pods' }));
     //
     // Generic objects we don't implement special functionality for.
     //
@@ -51,10 +53,8 @@ class Namespaces extends BaseObject {
       'services'
     ];
     for (const type of genericTypes) {
-      this[type] = new BaseObject({
-        path: `${ resourceOptions.parentPath }/${ type }`,
-        api: this.api
-      });
+      this[type] = new BaseObject(
+        Object.assign({}, resourceOptions, { name: type }));
     }
     this.types = ['replicationcontrollers', 'pods'].concat(genericTypes);
 

--- a/lib/pods.js
+++ b/lib/pods.js
@@ -12,10 +12,7 @@ class Pods extends BaseObject {
    * @param {string} options.path - Optional path of this resource
    */
   constructor(options) {
-    super(Object.assign({
-      path: `${ options.parentPath }/pods`,
-      api: options.api
-    }, options));
+    super(Object.assign({}, options, { name: options.name || 'pods' }));
   }
 
   /**

--- a/lib/replicationcontrollers.js
+++ b/lib/replicationcontrollers.js
@@ -14,7 +14,8 @@ class ReplicationControllerPods extends BaseObject {
    */
   constructor(options) {
     super(Object.assign({
-      path: `${ options.parentPath }/pods`,
+      name: 'pods',
+      parentPath: options.parentPath,
       api: options.api
     }, options));
     this.rc = options.rc;
@@ -63,10 +64,8 @@ class ReplicationControllers extends BaseObject {
    * @param {string} options.path - Optional path of this resource
    */
   constructor(options) {
-    super({
-      path: `${ options.parentPath }/replicationcontrollers`,
-      api: options.api
-    });
+    super(Object.assign({}, options, {
+      name: options.name || 'replicationcontrollers' }));
     this.pods = new ReplicationControllerPods({
       parentPath: options.parentPath,
       api: options.api,


### PR DESCRIPTION
Before this change our constructors for ReplicationControllers, Pods, and
Namespaces had different APIs than the BaseObject. This fixes the mismatch.