### PR TITLE
Add a wrapper for switching API clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ function print(err, result) {
 k8.namespaces.replicationcontrollers.get('http-rc', print);
 ```
 
-kubernetes-client supports the Extensions API also. For example, GET
+kubernetes-client supports the Extensions API group. For example, GET
 the `Deployment` named `http-deployment`:
 
 ```js
@@ -69,6 +69,32 @@ k8.namespaces.replicationcontrollers.patch({
   name: 'http-rc',
   body: patch
 }, print);
+```
+
+### Using the correct API group and version
+
+kubernetes-client client includes functionality to help determine the
+correct Kubernetes API group and version to use based on manifests:
+
+```js
+const K8Api = require('kubernetes-client');
+const api = new K8Api.Api({
+  url: 'http://my-k8-api-server.com',
+});
+
+const manifest0 = {
+  kind: 'Deployment',
+  apiVersion: 'extensions/v1beta1'
+  ...
+};
+const manifest1 = {
+  kind: 'ReplicationController',
+  apiVersion: 'v1'
+  ...
+};
+
+api.group(manifest0).ns.kind(manifest0).post(manifest0, print);
+api.group(manifest1).ns.kind(manifest1).post(manifest1, print);
 ```
 
 ### Object name aliases

--- a/lib/api.js
+++ b/lib/api.js
@@ -28,17 +28,17 @@ class Api {
   group(v) {
     const groupVersion = v.apiVersion || v;
     const pieces = groupVersion.split('/');
-    let group;
+    let Group;
     let version;
     if (pieces.length > 1) {
-      group = groups[pieces[0].toLowerCase()];
+      Group = groups[pieces[0].toLowerCase()];
       version = pieces[1];
     } else {
-      group = Core;
+      Group = Core;
       version = pieces[0];
     }
     const options = Object.assign({}, this.options,  { version });
-    return new group(options);
+    return new Group(options);
   }
 }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const Core = require('./core');
+const Extensions = require('./extensions');
+
+const groups = {
+  extensions: Extensions
+};
+
+class Api {
+  /**
+   * Create an API client wrapper object.
+   * @param {object} options - Options to pass to client constructors
+   * @param {object} options.core - Optional default Core client
+   * @param {object} options.extensions - Optional default Extensions client
+   */
+  constructor(options) {
+    this.options = options;
+    this.core = options.core || new Core(options);
+    this.extensions = options.extensions || new Extensions(options);
+  }
+
+  /**
+   * Return an API client for the given API group and version.
+   * @param {object|string} v - Kubernetes manifest object or a string
+   * @returns {ApiGroup} API client object.
+   */
+  group(v) {
+    const groupVersion = v.apiVersion || v;
+    const pieces = groupVersion.split('/');
+    let group;
+    let version;
+    if (pieces.length > 1) {
+      group = groups[pieces[0].toLowerCase()];
+      version = pieces[1];
+    } else {
+      group = Core;
+      version = pieces[0];
+    }
+    const options = Object.assign({}, this.options,  { version });
+    return new group(options);
+  }
+}
+
+module.exports = Api;

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const assume = require('assume');
+
+const Api = require('../lib/api');
+const Core = require('../lib/core');
+const Extensions = require('../lib/extensions');
+
+describe('lib.api', () => {
+  describe('Api', () => {
+    it('returns Core', () => {
+      const api = new Api({});
+      assume(api.group('v1').constructor).equals(Core);
+      assume(api.group({ apiVersion: 'v1' }).constructor).equals(Core);
+    });
+    it('returns Extensions', () => {
+      const api = new Api({});
+      const result = api.group('extensions/v1beta1');
+      assume(result.constructor).equals(Extensions);
+      assume(result.version).equals('v1beta1');
+    });
+  });
+});


### PR DESCRIPTION
E.g.,
```
const api = new Api(...);
api.core.ns.po.get(...);
api.group('extensions/v1beta1').ns.deployments.get(...);
api.group(manifest).ns.kind(manifest).post(...);
```