### PR TITLE
Fixed an issue with aliasing and `kind` error

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ correct Kubernetes API group and version to use based on manifests:
 const K8Api = require('kubernetes-client');
 const api = new K8Api.Api({
   url: 'http://my-k8-api-server.com',
-  namespace: 'test-ns'
+  namespace: 'my-project'
 });
 
 const manifest0 = {

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ correct Kubernetes API group and version to use based on manifests:
 const K8Api = require('kubernetes-client');
 const api = new K8Api.Api({
   url: 'http://my-k8-api-server.com',
+  namespace: 'test-ns'
 });
 
 const manifest0 = {

--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -172,6 +172,7 @@ function ns(api) {
   namespacer.get = api._defaultNs.get.bind(api._defaultNs);
   namespacer.post = api._defaultNs.post.bind(api._defaultNs);
   namespacer.delete = api._defaultNs.delete.bind(api._defaultNs);
+  namespacer.kind = api._defaultNs.kind.bind(api._defaultNs);
 
   //
   // Alias objects to the standard namespaces

--- a/lib/common.js
+++ b/lib/common.js
@@ -25,13 +25,23 @@ module.exports.aliasResources = function (resourceObject) {
     services: ['svc']
   };
 
+  const esRemoval = [
+    'componentstatuses',
+    'ingresses'
+  ];
+
   for (const resourceType of Object.keys(resourceAliases)) {
     if (resourceObject[resourceType]) {
       for (const alias of resourceAliases[resourceType]) {
         resourceObject[alias] = resourceObject[resourceType];
       }
-      // Alias without the ending 's'
-      const single = resourceType.substr(0,  resourceType.length - 1);
+
+      let length = 1;
+      // Alias without the ending 's' or 'es'
+      if (esRemoval.indexOf(resourceType) > -1) {
+        length = 2;
+      }
+      const single = resourceType.substr(0,  resourceType.length - length);
       resourceObject[single] = resourceObject[resourceType];
     }
   }

--- a/lib/common.js
+++ b/lib/common.js
@@ -25,10 +25,10 @@ module.exports.aliasResources = function (resourceObject) {
     services: ['svc']
   };
 
-  const esRemoval = [
-    'componentstatuses',
-    'ingresses'
-  ];
+  const esPlurals = {
+    componentstatuses: true,
+    ingresses: true
+  };
 
   for (const resourceType of Object.keys(resourceAliases)) {
     if (resourceObject[resourceType]) {
@@ -36,12 +36,8 @@ module.exports.aliasResources = function (resourceObject) {
         resourceObject[alias] = resourceObject[resourceType];
       }
 
-      let length = 1;
-      // Alias without the ending 's' or 'es'
-      if (esRemoval.indexOf(resourceType) > -1) {
-        length = 2;
-      }
-      const single = resourceType.substr(0,  resourceType.length - length);
+      const trimLength = esPlurals[resourceType] ? 2 : 1;
+      const single = resourceType.substr(0,  resourceType.length - trimLength);
       resourceObject[single] = resourceObject[resourceType];
     }
   }

--- a/test/api-group.test.js
+++ b/test/api-group.test.js
@@ -6,6 +6,7 @@ const nock = require('nock');
 
 const common = require('./common');
 const api = common.api;
+const apiGroup = common.apiGroup;
 const defaultName = common.defaultName;
 const beforeTesting = common.beforeTesting;
 
@@ -26,6 +27,13 @@ function pod(name) {
         imagePullPolicy: 'IfNotPresent'
       }]
     }
+  };
+}
+
+function ingress() {
+  return {
+    kind: 'Ingress',
+    apiVersion: 'extensions/v1beta1'
   };
 }
 
@@ -75,6 +83,23 @@ describe('lib.api-group', () => {
         assume(err).is.falsy();
         const namespace = results[1];
         assume(namespace.metadata.name).is.equal(defaultName);
+        done();
+      });
+    });
+  });
+
+  describe('.ingresses', () => {
+    beforeTesting('unit', () => {
+      nock(api.url)
+        .get(`/apis/extensions/v1beta1/namespaces/${ defaultName }/ingresses`)
+        .reply(200);
+    });
+
+    it('GETs', done => {
+      async.series([
+        next => { apiGroup.group(ingress()).ns.kind(ingress()).get(next); }
+      ], (err, results) => {
+        assume(err).is.falsy();
         done();
       });
     });

--- a/test/common.js
+++ b/test/common.js
@@ -3,6 +3,7 @@
 
 const Core = require('../lib/core');
 const Extensions = require('../lib/extensions');
+const Api = require('../lib/api');
 
 const defaultName = process.env.NAMESPACE || 'integration-tests';
 const defaultTimeout = process.env.TIMEOUT || 30000;
@@ -28,6 +29,7 @@ function only(types, message, fn) {
 
 let api;
 let extensions;
+let apiGroup;
 if (testing('int')) {
   if (!process.env.URL) {
     throw new RangeError(
@@ -43,6 +45,11 @@ if (testing('int')) {
   extensions = new Extensions({
     url: process.env.URL,
     version: process.env.VERSION || 'v1beta1',
+    namespace: defaultName
+  });
+
+  apiGroup = new Api({
+    url: process.env.URL,
     namespace: defaultName
   });
 
@@ -70,6 +77,11 @@ if (testing('int')) {
     namespace: defaultName
   });
 
+  apiGroup = new Api({
+    url: 'http://mock.kube.api',
+    namespace: defaultName
+  });
+
   api.wipe = () => {
     throw new Error("Don't call wipe during unit tests");
   }
@@ -77,6 +89,7 @@ if (testing('int')) {
 
 module.exports.api = api;
 module.exports.extensions = extensions;
+module.exports.apiGroup = apiGroup;
 module.exports.defaultName = defaultName;
 module.exports.testing = testing;
 module.exports.beforeTesting = beforeTesting;


### PR DESCRIPTION
The `kind` method was not bound correctly and would throw an error stating that `kind` was not a function. I also noticed an issues where resources that ended in `es` were not being aliased to their singular version correctly. An example is `ingresses` would alias to `ingresse`. 