### PR TITLE
Improve integration testing framework to give more consistent results

### DIFF
--- a/test/extensions.test.js
+++ b/test/extensions.test.js
@@ -5,15 +5,12 @@ const async = require('async');
 const nock = require('nock');
 
 const common = require('./common');
-const extensions = common.extensions;
-const api = common.api;
-const defaultName = common.defaultName;
 const beforeTesting = common.beforeTesting;
 const resourceName = 'test';
 
 describe('lib.extensions', () => {
   describe('.deployments', () => {
-    const path = `/apis/extensions/v1beta1/namespaces/${ defaultName }/deployments`;
+    const path = `/apis/extensions/v1beta1/namespaces/${ common.currentName }/deployments`;
     const resourcePath = `${ path }/${ resourceName }`;
     const deploymentObj = {
       kind: 'Deployment',
@@ -41,7 +38,7 @@ describe('lib.extensions', () => {
       }
     };
 
-    beforeTesting('int', api.wipe);
+    beforeTesting('int', common.changeName);
     beforeTesting('unit', () => {
       const mockDeployment = {
         kind: 'Deployment',
@@ -49,7 +46,7 @@ describe('lib.extensions', () => {
           name: resourceName
         }
       };
-      nock(extensions.url)
+      nock(common.extensions.url)
         .post(path)
         .reply(201, mockDeployment)
         .get(resourcePath)
@@ -61,10 +58,10 @@ describe('lib.extensions', () => {
     it('POSTs, GETs, and DELETEs', done => {
       async.series([
         next => {
-          extensions.ns.deployments.post({ body: deploymentObj }, next);
+          common.extensions.ns.deployments.post({ body: deploymentObj }, next);
         },
-        next => extensions.ns.deployments.get(resourceName, next),
-        next => extensions.ns.deployments.delete(resourceName, next)
+        next => common.extensions.ns.deployments.get(resourceName, next),
+        next => common.extensions.ns.deployments.delete(resourceName, next)
       ], (err, results) => {
         assume(err).is.falsy();
         const deployments = results[0];
@@ -74,20 +71,20 @@ describe('lib.extensions', () => {
     });
 
     describe('lists', () => {
-      beforeTesting('int', api.wipe);
+      beforeTesting('int', common.changeName);
       beforeTesting('unit', () => {
         const mockDeploymentList = {
           kind: 'DeploymentList',
           items: []
         };
-        nock(extensions.url)
+        nock(common.extensions.url)
           .get(path)
           .reply(200, mockDeploymentList);
       });
 
       it('returns DeploymentList', done => {
         async.series([
-          next => extensions.ns.deployments.get(next)
+          next => common.extensions.ns.deployments.get(next)
         ], (err, results) => {
           assume(err).is.falsy();
           const deploymentList = results[0];
@@ -99,7 +96,7 @@ describe('lib.extensions', () => {
   });
 
   describe('.ds', () => {
-    const path = `/apis/extensions/v1beta1/namespaces/${ defaultName }/daemonsets`;
+    const path = `/apis/extensions/v1beta1/namespaces/${ common.currentName }/daemonsets`;
     const resourcePath = `${ path }/${ resourceName }`;
     const daemonSetObj = {
       kind: 'DaemonSet',
@@ -126,7 +123,7 @@ describe('lib.extensions', () => {
       }
     };
 
-    beforeTesting('int', api.wipe);
+    beforeTesting('int', common.changeName);
     beforeTesting('unit', () => {
       const mockDs = {
         kind: 'DaemonSet',
@@ -134,7 +131,7 @@ describe('lib.extensions', () => {
           name: resourceName
         }
       };
-      nock(extensions.url)
+      nock(common.extensions.url)
         .post(path)
         .reply(201, mockDs)
         .get(resourcePath)
@@ -146,10 +143,10 @@ describe('lib.extensions', () => {
     it('POSTs, GETs, and DELETEs', done => {
       async.series([
         next => {
-          extensions.ns.ds.post({ body: daemonSetObj }, next);
+          common.extensions.ns.ds.post({ body: daemonSetObj }, next);
         },
-        next => extensions.ns.ds.get(resourceName, next),
-        next => extensions.ns.ds.delete(resourceName, next)
+        next => common.extensions.ns.ds.get(resourceName, next),
+        next => common.extensions.ns.ds.delete(resourceName, next)
       ], (err, results) => {
         assume(err).is.falsy();
         const ds = results[0];
@@ -159,21 +156,21 @@ describe('lib.extensions', () => {
     });
 
     describe('lists', () => {
-      beforeTesting('int', api.wipe);
+      beforeTesting('int', common.changeName);
       beforeTesting('unit', () => {
         const mockDsList = {
           kind: 'DaemonSetList',
           items: []
         };
 
-        nock(extensions.url)
+        nock(common.extensions.url)
           .get(path)
           .reply(200, mockDsList);
       });
 
       it('returns DaemonSetList', done => {
         async.series([
-          next => extensions.ns.ds.get(next)
+          next => common.extensions.ns.ds.get(next)
         ], (err, results) => {
           assume(err).is.falsy();
           const dsList = results[0];
@@ -183,4 +180,6 @@ describe('lib.extensions', () => {
       });
     });
   });
+
+  common.afterTesting('int', common.cleanupName);
 });

--- a/test/objects.test.js
+++ b/test/objects.test.js
@@ -6,9 +6,7 @@ const ReplicationControllers = require('../lib/replicationcontrollers');
 const Core = require('../lib/core');
 
 const common = require('./common');
-const api = common.api;
 const only = common.only;
-const defaultName = common.defaultName;
 const beforeTesting = common.beforeTesting;
 
 const testReplicationController = {
@@ -156,15 +154,15 @@ describe('objects', function () {
   });
 
   describe('.ReplicationControllers.post', function () {
-    beforeTesting('int', api.wipe);
+    beforeTesting('int', common.changeName);
     beforeTesting('unit', () => {
-      nock(api.url)
-        .post(`/api/v1/namespaces/${ defaultName }/replicationcontrollers`)
+      nock(common.api.url)
+        .post(`/api/v1/namespaces/${ common.currentName }/replicationcontrollers`)
         .reply(200, testReplicationController);
     });
 
     it('creates a ReplicationController', function (done) {
-      api.ns.rc.post({ body: testReplicationController }, (err, result) => {
+      common.api.ns.rc.post({ body: testReplicationController }, (err, result) => {
         assume(err).is.falsy();
         assume(result.metadata.name).is.equal('test-rc');
         done();
@@ -174,18 +172,18 @@ describe('objects', function () {
 
   describe('.ReplicationControllers.put', function () {
     beforeTesting('int', done => {
-      api.wipe(err => {
+      common.changeName(err => {
         assume(err).is.falsy();
-        api.ns.rc.post({ body: testReplicationController }, done);
+        common.api.ns.rc.post({ body: testReplicationController }, done);
       });
     });
     beforeTesting('unit', () => {
-      nock(api.url)
-        .put(`/api/v1/namespaces/${ defaultName }/replicationcontrollers/test-rc`)
+      nock(common.api.url)
+        .put(`/api/v1/namespaces/${ common.currentName }/replicationcontrollers/test-rc`)
         .reply(200, testReplicationController);
     });
     it('PUTs the new manifest', function (done) {
-      api.ns.rc.put({ name: 'test-rc', body: testReplicationController }, (err, result) => {
+      common.api.ns.rc.put({ name: 'test-rc', body: testReplicationController }, (err, result) => {
         assume(err).is.falsy();
         assume(result.metadata.name).is.equal('test-rc');
         done();
@@ -193,4 +191,5 @@ describe('objects', function () {
     });
   });
 
+  common.afterTesting('int', common.cleanupName);
 });


### PR DESCRIPTION
Each time we need a fresh namespace, generate a new name, instead of recycling
(deleting and re-creating) a single name. Removing a namespace isn't
synchronous and can be stuck in 'Terminating' for a while, especially on
minikube. That resulted in timeouts, or very long running tests.