### PR TITLE
Reduce duplicated code in tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -147,23 +147,24 @@ function changeNameInt(cb) {
 }
 
 function changeNameUnit() {
+  const mockUrl = 'http://mock.kube.api';
   const currentName = newName();
   module.exports.currentName = currentName;
 
   module.exports.api = new Core({
-    url: 'http://mock.kube.api',
+    url: mockUrl,
     version: process.env.VERSION || 'v1',
     namespace: currentName
   });
 
   module.exports.extensions = new Extensions({
-    url: 'http://mock.kube.api',
+    url: mockUrl,
     version: process.env.VERSION || 'v1beta1',
     namespace: currentName
   });
 
   module.exports.apiGroup = new Api({
-    url: 'http://mock.kube.api',
+    url: mockUrl,
     namespace: currentName
   });
 }


### PR DESCRIPTION
While trying to write tests for #57 I stumbled over a lot of duplication. 

This PR tries to reduce this duplication. 

One area that I still have to understand is the duplication inside the tests -- from what I can see we should be able to write generic tests for each of the types that are marked as 'generic' in the actual library, with the only variations being the actual resource and the API group to use.