### PR TITLE
fix(error handling): handle API errors that aren't JSON

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -6,8 +6,8 @@ function cb200(cb) {
   return function (err, result) {
     if (err) return cb(err);
     if (result.statusCode < 200 || result.statusCode > 299) {
-      const error = new Error(result.body.message);
-      error.code = result.body.code;
+      const error = new Error(result.body.message || result.body);
+      error.code = result.body.code || result.statusCode;
       return cb(error);
     }
     cb(null, result.body);


### PR DESCRIPTION
One example is 401 "Unauthorized\n".