### PR TITLE
chore(remove old code): remove old "namespacer" code

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -39,7 +39,7 @@ class ApiGroup {
     //
     // Create the default namespace so we have it directly on the API
     //
-    this._defaultNs = new Namespaces({
+    this.namespaces = new Namespaces({
       api: this,
       parentPath: this.path,
       namespace: options.namespace
@@ -55,11 +55,6 @@ class ApiGroup {
         api: this
       });
     }
-    //
-    // Special case - the namespacer shortcut:
-    //   api.ns.rc vs api.ns('default').rc
-    //
-    this.namespaces = ns(this);
     aliasResources(this);
   }
 
@@ -160,35 +155,6 @@ class ApiGroup {
       headers: { 'content-type': 'application/json' }
     }), cb);
   }
-}
-
-//
-// Create a factory function for a namespace when executed as a function
-//
-function ns(api) {
-
-  function namespacer(namespace) {
-    return new Namespaces({
-      api: api,
-      parentPath: api.path,
-      namespace: namespace
-    });
-  }
-
-  //
-  // Methods for root /api/v1/namespaces
-  //
-  namespacer.get = api._defaultNs.get.bind(api._defaultNs);
-  namespacer.post = api._defaultNs.post.bind(api._defaultNs);
-  namespacer.delete = api._defaultNs.delete.bind(api._defaultNs);
-  namespacer.kind = api._defaultNs.kind.bind(api._defaultNs);
-
-  //
-  // Alias objects to the standard namespaces
-  //
-  api._defaultNs.types.forEach(type => { namespacer[type] = api._defaultNs[type] });
-  aliasResources(namespacer);
-  return namespacer;
 }
 
 module.exports = ApiGroup;

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -17,14 +17,24 @@ class Namespaces extends BaseObject {
    * @param {string} options.path - Optional path of this resource
    */
   constructor(options) {
+    const api = options.api;
+    const parentPath = options.parentPath;
+    const call = name => {
+      return new this.constructor({
+        api: api,
+        namespace: name,
+        parentPath: parentPath
+      });
+    };
+
     super(Object.assign({
+      api: api,
+      fn: call,
       name: 'namespaces',
-      parentPath: options.parentPath,
-      api: options.api
+      parentPath: parentPath
     }, options));
 
     this.namespace = options.namespace || 'default';
-
     const resourceOptions = {
       api: this.api,
       parentPath: `${ this.path }/${ this.namespace }`


### PR DESCRIPTION
The BaseObject is callable by default, so the original "namespacer" hack is
superfluous. See d083f93be23182f4a629c02cdd319692a09168f8.