### PR TITLE
refactor(Namespaces): implement `.addResource`

### DIFF
--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -7,6 +7,27 @@ const BaseObject = require('./base');
 const ReplicationControllers = require('./replicationcontrollers');
 const Pods = require('./pods');
 
+const DEFAULT_RESOURCES = [
+  { name: 'replicationcontrollers', Constructor: ReplicationControllers },
+  { name: 'pods', Constructor: Pods }
+].concat([
+  'configmaps',
+  'daemonsets',
+  'deployments',
+  'endpoints',
+  'events',
+  'horizontalpodautoscalers',
+  'ingresses',
+  'jobs',
+  'limitranges',
+  'persistentvolumeclaims',
+  'replicasets',
+  'resourcequotas',
+  'secrets',
+  'serviceaccounts',
+  'services'
+]);
+
 class Namespaces extends BaseObject {
   /**
    * Create a Namespaces Kubernetes API object
@@ -23,7 +44,8 @@ class Namespaces extends BaseObject {
       return new this.constructor({
         api: api,
         namespace: name,
-        parentPath: parentPath
+        parentPath: parentPath,
+        resources: this.resources
       });
     };
 
@@ -35,39 +57,10 @@ class Namespaces extends BaseObject {
     }, options));
 
     this.namespace = options.namespace || 'default';
-    const resourceOptions = {
-      api: this.api,
-      parentPath: `${ this.path }/${ this.namespace }`
-    };
-    this.replicationcontrollers = new ReplicationControllers(
-      Object.assign({}, resourceOptions, { name: 'replicationcontrollers' }));
-    this.pods = new Pods(
-      Object.assign({}, resourceOptions, { name: 'pods' }));
-    //
-    // Generic objects we don't implement special functionality for.
-    //
-    const genericTypes = [
-      'configmaps',
-      'daemonsets',
-      'deployments',
-      'endpoints',
-      'events',
-      'horizontalpodautoscalers',
-      'ingresses',
-      'jobs',
-      'limitranges',
-      'persistentvolumeclaims',
-      'replicasets',
-      'resourcequotas',
-      'secrets',
-      'serviceaccounts',
-      'services'
-    ];
-    for (const type of genericTypes) {
-      this[type] = new BaseObject(
-        Object.assign({}, resourceOptions, { name: type }));
-    }
-    this.types = ['replicationcontrollers', 'pods'].concat(genericTypes);
+
+    this.resources = [];
+    const resources = options.resources || DEFAULT_RESOURCES;
+    resources.forEach(resource => this.addResource(resource));
 
     aliasResources(this);
   }
@@ -85,6 +78,20 @@ class Namespaces extends BaseObject {
         next(new Error('Waiting for namespace removal'));
       });
     }, cb);
+  }
+
+  addResource(options) {
+    if (typeof options === 'string') {
+      options = { name: options, Constructor: BaseObject };
+    }
+    const resourceOptions = {
+      api: this.api,
+      name: options.name,
+      parentPath: `${ this.path }/${ this.namespace }`
+    };
+    this[options.name] = new options.Constructor(resourceOptions);
+    this.resources.push(Object.assign({}, options));
+    return this;
   }
 
   /**

--- a/test/namespaces.test.js
+++ b/test/namespaces.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assume = require('assume');
+
+const Namespaces = require('../lib/namespaces');
+
+describe('lib.namespaces', () => {
+  describe('.addResource', () => {
+    it('adds a new resource object', () => {
+      const api = {};
+      const parentPath = '/apis/foo.com/v1';
+      const namespace = 'notdefault';
+      const namespaces = new Namespaces({ api, parentPath, namespace });
+      namespaces
+        .addResource('balonies')
+        .addResource('ducks');
+      assume(namespaces.balonies.constructor.name).is.equal('BaseObject');
+      assume(namespaces.ducks.constructor.name).is.equal('BaseObject');
+    });
+
+    it('ensures named namespaces inherit resources', () => {
+      const api = {};
+      const parentPath = '/apis/foo.com/v1';
+      const namespace = 'notdefault';
+      const namespaces = new Namespaces({ api, parentPath, namespace });
+      namespaces
+        .addResource('balonies')
+      const namespacesFoo = namespaces('foo');
+      assume(namespacesFoo.balonies.constructor.name).is.equal('BaseObject');
+    });
+  });
+});


### PR DESCRIPTION
`.addResource` adds a resource to the default namespace
(i.e., `api.core.ns.newResource`) and ensures the resource is passed to the
named namespaces (i.e., `api.core.ns('foo').newResource`).  The intended use
case case for `.addResource` is with ThirdPartyResource defined objects.