### PR TITLE
refactor(testing): drop "support" for passing VERSION to integration tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -103,7 +103,6 @@ function changeNameInt(cb) {
     ca: ca,
     cert: cert,
     key: key,
-    version: process.env.VERSION || 'v1',
     namespace: currentName
   });
 
@@ -112,7 +111,6 @@ function changeNameInt(cb) {
     ca: ca,
     cert: cert,
     key: key,
-    version: process.env.VERSION || 'v1beta1',
     namespace: currentName
   });
 
@@ -163,13 +161,11 @@ function changeNameUnit() {
 
   module.exports.api = new Core({
     url: url,
-    version: process.env.VERSION || 'v1',
     namespace: currentName
   });
 
   module.exports.extensions = new Extensions({
     url: url,
-    version: process.env.VERSION || 'v1beta1',
     namespace: currentName
   });
 


### PR DESCRIPTION
VERSION was cruft: it didn't work well, was only partially implemented.