### PR TITLE
Reduce duplicated code in test/common.js

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -161,11 +161,13 @@ function changeNameUnit() {
 
   module.exports.api = new Core({
     url: url,
+    version: process.env.VERSION || 'v1',
     namespace: currentName
   });
 
   module.exports.extensions = new Extensions({
     url: url,
+    version: process.env.VERSION || 'v1beta1',
     namespace: currentName
   });
 


### PR DESCRIPTION
This refactor makes it easier to add new API objects to the test framework.

This is an update of https://github.com/godaddy/kubernetes-client/pull/59