### PR TITLE
Use ca.crt correctly

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
-const certPath = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';
+const caPath = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';
 const tokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token';
 const namespacePath = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
 
@@ -27,13 +27,13 @@ function getInCluster () {
       ' and KUBERNETES_SERVICE_PORT must be defined');
   }
 
-  const cert = fs.readFileSync(certPath, 'utf8');
+  const ca = fs.readFileSync(caPath, 'utf8');
   const bearer = fs.readFileSync(tokenPath, 'utf8');
   const namespace = fs.readFileSync(namespacePath, 'utf8');
 
   return {
     url: `https://${host}:${port}`,
-    cert,
+    ca,
     auth: { bearer },
     namespace
   };

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -31,7 +31,7 @@ describe('Config', () => {
 
       fsReadFileSync
         .withArgs('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt')
-        .returns('my-cert')
+        .returns('my-ca')
 
       fsReadFileSync
         .withArgs('/var/run/secrets/kubernetes.io/serviceaccount/token')
@@ -44,7 +44,7 @@ describe('Config', () => {
       const configInCluster = config.getInCluster();
       assume(configInCluster).eqls({
         auth: { bearer: 'my-token' },
-        cert: 'my-cert',
+        ca: 'my-ca',
         namespace: 'my-namespace',
         url: 'https://myhost:443'
       });


### PR DESCRIPTION
The ca.crt file inside a pod is the 'certificate authority', not a 'client certificate'.

---
This should fix errors 'unable to verify the first certificate' when using the in-cluster configuration.