### PR TITLE
Make check for content-type more generic

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -97,7 +97,7 @@ class ApiGroup {
 
     return request(requestOptions, (err, res, body) => {
       if (err) return cb(err);
-      if (res.headers['content-type'] === 'application/json') {
+      if (res.headers['content-type'].indexOf('application/json') === 0) {
         body = JSON.parse(body);
       }
       cb(null, { statusCode: res.statusCode, body: body });


### PR DESCRIPTION
Adds support for server responses where the charset is also specified in Content-Type.
For example: 'application/json; charset=utf-8'