### PR TITLE
fix(response `content-type` checking): more robust JSON response handling

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -88,7 +88,8 @@ class ApiGroup {
     const requestOptions = Object.assign({
       method: method || 'GET',
       uri: this._url(options.path),
-      body: options.body && JSON.stringify(options.body),
+      body: options.body,
+      json: true,
       qs: options.qs,
       headers: options.headers
     }, this.requestOptions);
@@ -97,9 +98,6 @@ class ApiGroup {
 
     return request(requestOptions, (err, res, body) => {
       if (err) return cb(err);
-      if (res.headers['content-type'] === 'application/json') {
-        body = JSON.parse(body);
-      }
       cb(null, { statusCode: res.statusCode, body: body });
     });
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "async": "^2.0.0-rc.6",
     "js-yaml": "^3.7.0",
-    "request": "^2.72.0"
+    "request": "^2.79.0"
   },
   "devDependencies": {
     "assume": "^1.4.1",


### PR DESCRIPTION
Use `json: true` with request: request has more robust `content-type` checking.