### PR TITLE
fix(matchLabels): call BaseObject constructor with correct arguments

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -42,9 +42,11 @@ class BaseObject extends CallableObject {
    *
    * @param {object} options - Options object
    * @param {string} options.api - Kubernetes API URL
+   * @param {string} options.name - kubernetes resource name
+   * @param {string} options.parentPath - Kubernetes resource paprent path
    * @param {string} options.fn - Optional function to invoke when object is
-   * called.
-   * @param {string} options.path - Kubernetes resource path
+   * called
+   * @param {string} options.qs - Optional query string object
    */
   constructor(options) {
     const api = options.api;
@@ -62,10 +64,13 @@ class BaseObject extends CallableObject {
     }
 
     super(fn);
-    this.parentPath = options.parentPath;
     this.api = api;
-    this.path = path;
+    this._name = options.name;
+    this.parentPath = options.parentPath;
+    this.fn = options.fn;
     this.qs = options.qs || {};
+
+    this.path = path;
   }
 
   /**
@@ -151,7 +156,13 @@ class BaseObject extends CallableObject {
     const qs = Object.assign({}, this.qs, {
       labelSelector: matchExpression.stringify(expressions)
     });
-    return new this.constructor(Object.assign({}, this, { qs }));
+    return new this.constructor({
+      api: this.api,
+      name: this._name,
+      parentPath: this.parentPath,
+      fn: this.fn,
+      qs
+    });
   }
 
   /**


### PR DESCRIPTION
[1] changed BaseObject so that its properties were no longer a
superset of the `options` BaseObject construtor argument (specifically
removing the `name` property). That broke `.match()` and
`.matchLabels()` which depended on that property.

Fixes: #90

[1]:https://github.com/godaddy/kubernetes-client/commit/d083f93be23182f4a629c02cdd319692a09168f8#diff-86b75ecfbd25aa771c8e9e0dff8eb00fL25