### PR TITLE
(fix/feature) Do not override user-provided headers in ApiGroup.patch options, to allow switching patch strategy 

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -127,7 +127,7 @@ class ApiGroup {
    * @param {callback} cb - The callback that handles the response
    */
   patch(options, cb) {
-    this._request('PATCH', Object.assign({}, {
+    this._request('PATCH', Object.assign({
       headers: { 'content-type': 'application/strategic-merge-patch+json' }
     }, options), cb);
   }

--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -127,9 +127,9 @@ class ApiGroup {
    * @param {callback} cb - The callback that handles the response
    */
   patch(options, cb) {
-    this._request('PATCH', Object.assign({}, options, {
+    this._request('PATCH', Object.assign({}, {
       headers: { 'content-type': 'application/strategic-merge-patch+json' }
-    }), cb);
+    }, options), cb);
   }
 
   /**

--- a/lib/base.js
+++ b/lib/base.js
@@ -8,7 +8,7 @@ function cb200(cb) {
     if (result.statusCode < 200 || result.statusCode > 299) {
       const error = new Error(result.body.message || result.body);
       error.code = result.body.code || result.statusCode;
-      return cbba(error);
+      return cb(error);
     }
     cb(null, result.body);
   };
@@ -116,7 +116,7 @@ class BaseObject extends CallableObject {
 
   /**
    * Patch a Kubernetes resource
-   * @param {RequestOptions} options - PATCH options
+   * @param {RequestOptions} options - PATCH optionscb
    * @param {callback} cb - The callback that handle the response
    */
   patch(options, cb) {

--- a/lib/base.js
+++ b/lib/base.js
@@ -8,7 +8,7 @@ function cb200(cb) {
     if (result.statusCode < 200 || result.statusCode > 299) {
       const error = new Error(result.body.message || result.body);
       error.code = result.body.code || result.statusCode;
-      return cb(error);
+      return cbba(error);
     }
     cb(null, result.body);
   };
@@ -120,7 +120,7 @@ class BaseObject extends CallableObject {
    * @param {callback} cb - The callback that handle the response
    */
   patch(options, cb) {
-    this.api.patch({ path: this._path(options), body: options.body },
+    this.api.patch({ path: this._path(options), body: options.body, headers: options.headers },
                    cb200(cb));
   }
 


### PR DESCRIPTION
Kubernetes' PATCH operation accepts different patch strategies:

https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#patch-operations

By default, `kubernetes-client` reasonably uses `application/strategic-merge-patch+json`, however, it's currently impossible to choose a different strategy (which is exactly what I'm trying to do - strategic-merge-patch is problematic in certain situations when dealing with lists):

```js

  /**
   * Invoke a PATCH request against the Kubernetes API server
   * @param {ApiRequestOptions} options - Options object.
   * @param {callback} cb - The callback that handles the response
   */
  patch(options, cb) {
    this._request('PATCH', Object.assign({}, options, {
      headers: { 'content-type': 'application/strategic-merge-patch+json' }
    }), cb);
  }
```

As you can see, with the current setup, `headers` as merged in the `patch` method ALWAYS takes precedence.

My change reverses the order, allowing the caller to set custom headers, including the patch strategy:

```js
thing.patch({ body: {}, headers: { 'content-type': 'application/merge-patch+json' }, ...)
```

I kept this change to the smallest possible footprint, though you might consider allowing this sort of control at other places of the codebase. It was also unclear where the best place to test this change would be, so I'm open to suggestions.

Cheers!