### PR TITLE
refactor(ApiGroup): support custom root group resources

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -62,7 +62,7 @@ class ApiGroup {
   addResource(options) {
     if (typeof options === 'string') {
       options = { name: options, Constructor: BaseObject };
-    } else if (!option.name || !options.Constructor) {
+    } else if (!options.name || !options.Constructor) {
       throw new RangeError(
         'ApiGroup.addResource: options requires .name and .Constructor');
     }

--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -62,6 +62,14 @@ class ApiGroup {
   addResource(options) {
     if (typeof options === 'string') {
       options = { name: options, Constructor: BaseObject };
+    } else if (!option.name || !options.Constructor) {
+      throw new RangeError(
+        'ApiGroup.addResource: options requires .name and .Constructor');
+    }
+
+    if (this[options.name]) {
+      throw new RangeError(
+        `ApiGroup.addResource: .${ options.name } already exists`);
     }
     this[options.name] = new options.Constructor({
       api: this,

--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -46,16 +46,28 @@ class ApiGroup {
     });
 
     //
-    // Create resources that live at the root (e.g., /api/v1/nodes)
+    // Create "group" resources that live at the root (e.g., /api/v1/nodes)
     //
-    for (const type of options.genericTypes) {
-      this[type] = new BaseObject({
-        name: type,
-        parentPath: this.path,
-        api: this
-      });
-    }
+    options.groupTypes.forEach(type => this.addResource(type));
+
     aliasResources(this);
+  }
+
+  /**
+   * Add a resource (e.g., nodes) to the ApiGroup group
+   * @param {string|object} options - resource name or options object
+   * @param {string} options.name - resource name
+   * @param {fn} options.Constructor - constructor for new resource
+   */
+  addResource(options) {
+    if (typeof options === 'string') {
+      options = { name: options, Constructor: BaseObject };
+    }
+    this[options.name] = new options.Constructor({
+      api: this,
+      name: options.name,
+      parentPath: this.path
+    });
   }
 
   /**

--- a/lib/apps.js
+++ b/lib/apps.js
@@ -4,7 +4,7 @@ const ApiGroup = require('./api-group');
 
 class Apps extends ApiGroup {
   constructor(options) {
-    const genericTypes = [
+    const groupTypes = [
       // Deprecated name of statefulsets in kubernetes 1.4
       'petsets',
       'statefulsets'
@@ -12,7 +12,7 @@ class Apps extends ApiGroup {
     options = Object.assign({}, options, {
       path: 'apis/apps',
       version: options.version || 'v1beta1',
-      genericTypes: genericTypes
+      groupTypes: groupTypes
     });
     super(options);
   }

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -4,7 +4,7 @@ const ApiGroup = require('./api-group');
 
 class Batch extends ApiGroup {
   constructor(options) {
-    const genericTypes = [
+    const groupTypes = [
       'cronjobs',
       'jobs',
       // Deprecated name for cronjobs in kubernetes 1.4
@@ -13,7 +13,7 @@ class Batch extends ApiGroup {
     options = Object.assign({}, options, {
       path: 'apis/batch',
       version: options.version || 'v1',
-      genericTypes: genericTypes
+      groupTypes: groupTypes
     });
     super(options);
   }

--- a/lib/core.js
+++ b/lib/core.js
@@ -4,7 +4,7 @@ const ApiGroup = require('./api-group');
 
 class Core extends ApiGroup {
   constructor(options) {
-    const genericTypes = [
+    const groupTypes = [
       'componentstatuses',
       'configmaps',
       'endpoints',
@@ -24,7 +24,7 @@ class Core extends ApiGroup {
     options = Object.assign({}, options, {
       path: 'api',
       version: options.version || 'v1',
-      genericTypes: genericTypes
+      groupTypes: groupTypes
     });
     super(options);
   }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -4,7 +4,7 @@ const ApiGroup = require('./api-group');
 
 class Extensions extends ApiGroup {
   constructor(options) {
-    const genericTypes = [
+    const groupTypes = [
       'daemonsets',
       'deployments',
       'horizontalpodautoscalers',
@@ -16,7 +16,7 @@ class Extensions extends ApiGroup {
     options = Object.assign({}, options, {
       path: 'apis/extensions',
       version: options.version || 'v1beta1',
-      genericTypes: genericTypes
+      groupTypes: groupTypes
     });
     super(options);
   }

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -4,7 +4,7 @@ const ApiGroup = require('./api-group');
 
 class Rbac extends ApiGroup {
   constructor(options) {
-    const genericTypes = [
+    const groupTypes = [
       'clusterroles',
       'clusterrolebindings',
       'roles',
@@ -13,7 +13,7 @@ class Rbac extends ApiGroup {
     options = Object.assign({}, options, {
       path: 'apis/rbac.authorization.k8s.io',
       version: options.version || 'v1alpha1',
-      genericTypes: genericTypes
+      groupTypes: groupTypes
     });
     super(options);
   }

--- a/lib/third-party-resources.js
+++ b/lib/third-party-resources.js
@@ -8,7 +8,7 @@ class ThirdPartyResource extends ApiGroup {
     options = Object.assign({}, options, {
       path: `apis/${ options.group }`,
       version: options.version || 'v1',
-      genericTypes: []
+      groupTypes: []
     });
     super(options);
 
@@ -19,11 +19,7 @@ class ThirdPartyResource extends ApiGroup {
 
   addResource(resourceName) {
     this.namespace.addResource(resourceName);
-    this[resourceName] = new BaseObject({
-      api: this,
-      name: resourceName,
-      parentPath: this.path
-    });
+    super.addResource(resourceName);
     return this;
   }
 }

--- a/lib/third-party-resources.js
+++ b/lib/third-party-resources.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const ApiGroup = require('./api-group');
-const BaseObject = require('./base');
 
 class ThirdPartyResource extends ApiGroup {
   constructor(options) {

--- a/test/api-group.test.js
+++ b/test/api-group.test.js
@@ -66,6 +66,28 @@ describe('lib.api-group', () => {
     });
   });
 
+  describe('.addResource', () => {
+    afterEach(() => delete common.api.foo);
+
+    it('adds new group resources', () => {
+      common.api.addResource('foo');
+      assume(common.api.foo).is.truthy();
+    });
+    it('throws an error for missing .name', () => {
+      const fn = () => common.api.addResource({ Constructor: 'does not matter' });
+      assume(fn).throws();
+    });
+    it('throws an error for missing .Constructor', () => {
+      const fn = () => common.api.addResource({ name: 'does not matter' });
+      assume(fn).throws();
+    });
+    it('throws an error for same resource', () => {
+      const fn = () => common.api.addResource('foo');
+      fn();
+      assume(fn).throws();
+    });
+  });
+
   describe('.ingresses', () => {
     beforeTesting('unit', () => {
       nock(common.api.url)

--- a/test/third-party-resources.test.js
+++ b/test/third-party-resources.test.js
@@ -76,7 +76,6 @@ describe('lib.ThirdPartyResource', () => {
       });
 
       it('returns NewSourceList', done => {
-        common.thirdPartyResources.addResource('newresources');
         common.thirdPartyResources.newresources.get((err, results) => {
           assume(err).is.falsy();
           assume(results.kind).is.equal('NewResourceList');


### PR DESCRIPTION
The current code assumes every root group resources (e.g., /api/v1/nodes) is a
BaseObject. This adds support for custom resources (e.g., Pod or Deployment).
This is groundwork for:

https://github.com/godaddy/kubernetes-client/issues/47