### PR TITLE
support for auth-provider access-token in fromKubeconfig()

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -92,6 +92,10 @@ function fromKubeconfig(kubeconfig, current) {
       auth.bearer = user.token;
     }
 
+    if (user['auth-provider'] && user['auth-provider'].config && user['auth-provider'].config['access-token']) {
+      auth.bearer = user['auth-provider'].config['access-token'];
+    }
+
     if (user.username) auth.user = user.username;
     if (user.password) auth.pass = user.password;
   }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -166,6 +166,46 @@ describe('Config', () => {
       assume(args.auth.bearer).equals('foo-token');
     });
 
+    it('handles auth-provider.config.access-token', () => {
+      const kubeconfig = {
+        'apiVersion': 'v1',
+        'kind': 'Config',
+        'preferences': {},
+        'current-context': 'foo-context',
+        'contexts': [
+          {
+            name: 'foo-context',
+            context: {
+              cluster: 'foo-cluster',
+              user: 'foo-user'
+            }
+          }
+        ],
+        'clusters': [
+          {
+            name: 'foo-cluster',
+            cluster: {
+              server: 'https://192.168.42.121:8443'
+            }
+          }
+        ],
+        'users': [
+          {
+            name: 'foo-user',
+            user: {
+              'auth-provider': {
+                config: {
+                  'access-token': 'foo-token'
+                }
+              }
+            }
+          }
+        ]
+      };
+      const args = config.fromKubeconfig(kubeconfig);
+      assume(args.auth.bearer).equals('foo-token');
+    });
+
     it('handles manually specified current-context', () => {
       const kubeconfig = {
         'apiVersion': 'v1',


### PR DESCRIPTION
Using kubectl 1.6.4 client against Google Container Engine


```
 $ kubectl version
Client Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.4", GitCommit:"d6f433224538d4f9ca2f7ae19b252e6fcb66a3ae", GitTreeState:"clean", BuildDate:"2017-05-19T18:44:27Z", GoVersion:"go1.7.5", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"5", GitVersion:"v1.5.7", GitCommit:"8eb75a5810cba92ccad845ca360cf924f2385881", GitTreeState:"clean", BuildDate:"2017-04-27T09:42:05Z", GoVersion:"go1.7.5", Compiler:"gc", Platform:"linux/amd64"}
```

produces a different data structure in ~/.kube/config

```
- name: context-name
  user:
    auth-provider:
      config:
        access-token: token
        cmd-args: config config-helper --format=json
        cmd-path: /home/foo/google-cloud-sdk/bin/gcloud
        expiry: 2017-06-14T15:51:07Z
        expiry-key: '{.credential.token_expiry}'
        token-key: '{.credential.access_token}'
      name: some-name
```

This patch adds a feature to look for those keys in order to get the 'access-token' and then do an authenticated request against the current context