### PR TITLE
fix(undefined `options` passed to `.get`): set default `options` value to `{}`

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -105,6 +105,8 @@ class BaseObject extends CallableObject {
       options = {};
     } else if (typeof options === 'string') {
       options = { name: options };
+    } else if (typeof options === 'undefined') {
+      options = {};
     }
     const qs = Object.assign({}, this.qs, options.qs || {});
 


### PR DESCRIPTION
This fixes stream calls without an `options` argument.  E.g.,:

```
// This used to TypeError.
// Now it returns a stream.
const stream = core.ns.po.get();
```

https://github.com/godaddy/kubernetes-client/issues/37#issuecomment-259434515