### PR TITLE
feat(Add `getStream` to resource API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,14 +223,13 @@ core.ns.rc.delete({ name: 'http-rc', preservePods: true });
 
 ### Watching and streaming
 
-If you don't pass a callback to `get`, node-kubernetes returns a
-stream.  This is useful for watching:
+You can call `.getStream` to stream results. This is useful for watching:
 
 ```js
 const JSONStream = require('json-stream');
 const jsonStream = new JSONStream();
 
-const stream = core.ns.po.get({ qs: { watch: true } });
+const stream = core.ns.po.getStream({ qs: { watch: true } });
 stream.pipe(jsonStream);
 jsonStream.on('data', object => {
   console.log('Pod:', JSON.stringify(object, null, 2));
@@ -239,7 +238,7 @@ jsonStream.on('data', object => {
 
 You can access logs in a similar fashion:
 ```js
-const stream = core.ns.po.log({ name: 'http-123', qs: { follow: true } });
+const stream = core.ns.po('http-123').log.getStream({ qs: { follow: true } });
 stream.on('data', chunk => {
   process.stdout.write(chunk.toString());
 });

--- a/lib/base.js
+++ b/lib/base.js
@@ -117,6 +117,13 @@ class BaseObject extends CallableObject {
   }
 
   /**
+   * Get a Kubernetes resource
+   * @param {RequestOptions|string} options - GET options, or resource name
+   * @returns {Stream} Result stream
+   */
+  getStream(options) { return this.get(options); }
+
+  /**
    * Patch a Kubernetes resource
    * @param {RequestOptions} options - PATCH options
    * @param {callback} cb - The callback that handle the response

--- a/test/pods.test.js
+++ b/test/pods.test.js
@@ -162,6 +162,17 @@ describe('lib.pods', () => {
         done();
       });
     });
+    it('returns the Pod via a stream', done => {
+      const stream = common.api.ns.pods('test-pod').getStream();
+      const pieces = [];
+      stream.on('data', data => pieces.push(data.toString()));
+      stream.on('error', err => assume(err).is.falsy());
+      stream.on('end', () => {
+        const object = JSON.parse(pieces.join(''));
+        assume(object.kind).is.equal('Pod');
+        done();
+      });
+    });
     only('unit', 'returns the Pod via the legacy method', done => {
       common.api.ns.pods.get('test-pod', (err, pod) => {
         assume(err).is.falsy();


### PR DESCRIPTION
This change facilitates a Promised-based API (see [1] for discussion). The
original `request`-like behavior is unchanged: return a stream if the caller
omits a callback.

[1]: https://github.com/godaddy/kubernetes-client/issues/37