### PR TITLE
fix(Update README.md): Show correct delete usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ ReplicationController when it deletes the ReplicationController. You
 can preserve the Pods:
 
 ```js
-core.ns.rc.delete({ name: 'http-rc', preservePods: true });
+core.ns.rc.delete({ name: 'http-rc', preservePods: true }, print);
 ```
 
 ### Watching and streaming


### PR DESCRIPTION
README does not show proper use of `delete` method. Possibly caused confusion with how to use the method (see #120). 