### PR TITLE
feat(Deployments): Support apps/deployments

### DIFF
--- a/lib/apps.js
+++ b/lib/apps.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ApiGroup = require('./api-group');
+const Deployments = require('./deployments');
 
 class Apps extends ApiGroup {
   constructor(options) {
@@ -12,8 +13,10 @@ class Apps extends ApiGroup {
     options = Object.assign({}, options, {
       path: 'apis/apps',
       version: options.version || 'v1beta1',
-      groupResources: resources,
-      namespaceResources: resources
+      groupResources: resources.concat(['deployments']),
+      namespaceResources: resources.concat([
+        { name: 'deployments', Constructor: Deployments }
+      ])
     });
     super(options);
   }


### PR DESCRIPTION
Hey, are you interested in a PR for adding deployments under `apps` ? If so, I'll see about adding tests and all to this as well instead of just a one-liner. It looks like [apps/v1beta1.Deployment](https://github.com/kubernetes/kubernetes.github.io/pull/3814#issuecomment-303239179) "will eventually be the default," and is working that way in 1.6, but for the time being deployments are under both extensions and apps. 

I've only just started using this client library, and I know it's hard to support multiple versions at once, so I understand if you've got other concerns that would discourage this PR. Thanks!