### PR TITLE
feat(Promise API): Experimental support for a promise-based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,39 @@ const Api = require('kubernetes-client');
 const core = new Api.Core(Api.config.fromKubeconfig());
 ```
 
+### **Experimental** support for promises and async/await
+
+kubernetes-client exposes **experimental** support for promises via
+the `kubernetes-client/promise` path. The API is the same, except for the
+functions that previously took a callback (*e.g.*, `.get`). Those functions now
+return a promise.
+
+```js
+// Notice the require path...
+const Api = require('kubernetes-client/promise');
+// ...but the same constructor arguments.
+const core = new Api.Core({
+  url: 'http://my-k8s-api-server.com',
+  version: 'v1',  // Defaults to 'v1'
+  namespace: 'my-project' // Defaults to 'default'
+});
+```
+
+and then:
+
+```js
+core.namespaces.replicationcontrollers('http-rc').get()
+  .then(result => JSON.stringify(result, null, 2))
+  .catch(err => throw err);
+```
+
+or with `async/await`:
+
+```js
+const result = await core.namespaces.replicationcontrollers('http-rc').get();
+console.log(JSON.stringify(result, null, 2));
+```
+
 ### Creating and updating
 
 kubernetes-client objects expose `.post`, `.patch`, and `.put`

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -32,6 +32,7 @@ const BaseObjectHandler = {
     //    getStream(options) { return this.get(options); }
     //
     // would return a promise instead of a stream.
+    //
     if (typeof value === 'function' && value.bind) return value.bind(target);
 
     return wrap(value);

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const promisify = require('util.promisify');
+
+const api = require('./index');
+const ApiGroup = require('./api-group');
+const BaseObject = require('./base');
+
+function wrap(value) {
+  if (value instanceof BaseObject) return promisifyBaseObject(value);
+  if (value instanceof ApiGroup) return promisifyApiGroup(value);
+  return value;
+}
+
+const wrappedNames = new Set(['delete', 'get', 'patch', 'post', 'put']);
+
+const BaseObjectHandler = {
+  apply: function (target, thisArg, args) {
+    return wrap(target(...args));
+  },
+
+  get: function (target, name) {
+    const value = target[name];
+    if (wrappedNames.has(name)) return promisify(value);
+
+    //
+    // If it's a function we want to ensure it's bound to target and not the
+    // wrapping Proxy object. If we don't do this, code inside class
+    // implementations will might invoke the promisified functions instead of
+    // the callback based ones. E.g.,
+    //
+    //    getStream(options) { return this.get(options); }
+    //
+    // would return a promise instead of a stream.
+    if (typeof value === 'function' && value.bind) return value.bind(target);
+
+    return wrap(value);
+  }
+};
+
+function promisifyBaseObject(baseObject) {
+  return new Proxy(baseObject, BaseObjectHandler);
+}
+
+const ApiGroupHandler = {
+  get: function (target, name) {
+    return wrap(target[name]);
+  }
+};
+
+function promisifyApiGroup(apiGroup) {
+  return new Proxy(apiGroup, ApiGroupHandler);
+}
+
+module.exports = Object.keys(api).reduce((acc, name) => {
+  if (api[name] instanceof ApiGroup.constructor) {
+    acc[name] = class Wrapper {
+      constructor(...args) {
+        return wrap(new (api[name])(...args));
+      }
+    };
+    return acc;
+  }
+  acc[name] = api[name];
+  return acc;
+}, {});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "assign-deep": "^0.4.5",
     "async": "^2.4.1",
     "js-yaml": "^3.7.0",
-    "request": "^2.79.0"
+    "request": "^2.79.0",
+    "util.promisify": "^1.0.0"
   },
   "devDependencies": {
     "assume": "^1.4.1",

--- a/test/common.js
+++ b/test/common.js
@@ -11,6 +11,7 @@ const Api = require('../lib/api');
 const Apps = require('../lib/apps');
 const Batch = require('../lib/batch');
 const Core = require('../lib/core');
+const CorePromise = require('../lib/promise').Core;
 const Extensions = require('../lib/extensions');
 const Rbac = require('../lib/rbac');
 const ThirdPartyResources = require('../lib/third-party-resources');
@@ -71,6 +72,7 @@ function injectApis(options) {
     apiGroup: { Constructor: Api },
     apps: { Constructor: Apps },
     batch: { Constructor: Batch },
+    corePromise: { Constructor: CorePromise },
     extensions: { Constructor: Extensions },
     rbac: { Constructor: Rbac },
     thirdPartyResources: {

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const assume = require('assume');
+const nock = require('nock');
+
+const common = require('./common');
+const only = common.only;
+const beforeTestingEach = common.beforeTestingEach;
+
+describe('lib.promise', () => {
+  describe('Core', () => {
+    beforeTestingEach('unit', () => {
+      nock(common.api.url)
+        .get(`/api/v1/namespaces/${ common.currentName }/pods/test-pod`)
+        .reply(200, {
+          kind: 'Pod',
+          metadata: { name: 'test-pod' }
+        });
+    });
+
+    only('unit', '.get returns a Pod via a promise', done => {
+      const pods = common.corePromise.ns.po('test-pod').get();
+      pods.then(object => {
+        assume(object.kind).is.equal('Pod');
+        assume(object.metadata.name).is.equal('test-pod');
+        done();
+      });
+    });
+    only('unit', '.getStream returns the Pod via a stream', done => {
+      const stream = common.corePromise.ns.po('test-pod').getStream();
+      const pieces = [];
+      stream.on('data', data => pieces.push(data.toString()));
+      stream.on('error', err => assume(err).is.falsy());
+      stream.on('end', () => {
+        const object = JSON.parse(pieces.join(''));
+        assume(object.kind).is.equal('Pod');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This preserves the original callback-based "core" implementation and layers the
promised-based API on top of that core implementation. The goal is start using
and iterating on the promised-based API even if we expect the underlying
implementation to evolve (e.g., we could consider replacing the core
callback-based implementation with a promise one).  See
https://github.com/godaddy/kubernetes-client/issues/37 for discussion.

Example usage:

```js
async function main() {
  try {
    const pods = await core.ns('kube-system').po.get();
    console.log(`Watching: ${ JSON.stringify(pods, null, 2) }`);
    const stream = core.ns('kube-system').po.getStream({ qs: { watch: true }});
    stream.on('data', data => { console.log(data.toString()); });
    stream.on('error', err => { throw err; });
    stream.on('end', () => { console.log('end'); });
  } catch (error) {
    console.log(error);
  }
}
main();
```