### PR TITLE
Make possible to send body in delete requests

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -85,7 +85,7 @@ class BaseObject extends CallableObject {
     } else if (typeof options === 'string') {
       options = { name: options };
     }
-    this.api.delete({ path: this._path(options), qs: options.qs },
+    this.api.delete({ path: this._path(options), qs: options.qs, body: options.body },
                     cb200(cb));
   }
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -6,6 +6,7 @@ const async = require('async');
 const nock = require('nock');
 
 const common = require('./common');
+const only = common.only;
 const beforeTesting = common.beforeTesting;
 
 function pod(name) {
@@ -88,6 +89,30 @@ describe('lib.base', () => {
           assume(err).is.falsy();
           assume(pods.kind).is.equal('PodList');
           assume(pods.items).has.length(1);
+          done();
+        });
+      });
+    });
+
+    describe('.delete', () => {
+      const podName = 'pod-name';
+      const query = { pretty: true };
+      const body = {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        propagationPolicy: 'Foreground'
+      };
+      beforeTesting('unit', () => {
+        nock(common.api.url)
+          .delete(`/api/v1/namespaces/${ common.currentName }/pods/${ podName }`, body)
+          .query(query)
+          .reply(200, { kind: 'Pod' });
+      });
+
+      only('unit', 'should bypass query string and body from arguments into request', done => {
+        common.api.ns.po.delete({ name: podName, qs: query, body: body }, (err, result) => {
+          assume(err).is.falsy();
+          assume(result).is.eql({ kind: 'Pod' });
           done();
         });
       });


### PR DESCRIPTION
Some kubernetes api's requires to send body within delete request.
Examples: [job deletion](https://kubernetes.io/docs/api-reference/v1.7/#delete-41) and [pod deletion](https://kubernetes.io/docs/api-reference/v1.7/#delete-58)
I needed to send DeleteOptions in request body to make job deletion also to delete all related pods.

Changes in this pull request provides possibility to do this in same way, as it works for POSTs.
````
const K8s = require('kubernetes-client');
const batch = new K8s.Batch({/*add configuration*/});
batch.namespaces('default').jobs.delete({
    name: 'some-job',
    body: {
        kind: 'DeleteOptions',
        apiVersion: 'batch/v1',
        propagationPolicy: 'Foreground'
    }
}, (err, data) => console.log(err, data))

````
