### PR TITLE
Allow to overwrite `path`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -20,7 +20,7 @@ class Core extends ApiGroup {
       'services'
     ];
     options = Object.assign({}, options, {
-      path: 'api',
+      path: options.path || 'api',
       version: options.version || 'v1',
       groupResources: commonResources.concat([
         'componentstatuses',


### PR DESCRIPTION
First: Thanks for this :)

I'm using kubernetes-clienta against an openshift and some of the apis of OpenShift are at `/oapi/` instead of `/api/`

This patch allows to do:
```
const openshift = new Api.Core({
  url: 'https://192.168.99.105:8443',
  path: 'oapi',
});
```