### PR TITLE
fix: accept relative paths

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,6 +9,11 @@ const caPath = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';
 const tokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token';
 const namespacePath = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
 
+function defaultConfigPath() {
+  const homeDir = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
+  return path.join(homeDir, '.kube', 'config');
+}
+
 /**
 * Returns with in cluster config
 * Based on: https://github.com/kubernetes/client-go/blob/124670e99da15091e13916f0ad4b2b2df2a39cd5/rest/config.go#L274
@@ -47,7 +52,15 @@ module.exports.getInCluster = getInCluster;
 //
 /* eslint-disable complexity, max-statements */
 function fromKubeconfig(kubeconfig, current) {
-  if (!kubeconfig) kubeconfig = loadKubeconfig();
+  var configDir = '.';
+
+  if (!kubeconfig) {
+    const cfgPath = defaultConfigPath();
+    configDir = path.dirname(cfgPath);
+    kubeconfig = loadKubeconfig(cfgPath);
+  }
+
+  const normalizePath = (subPath) => path.join(configDir, path.normalize(subPath));
 
   current = current || kubeconfig['current-context'];
   const context = kubeconfig.contexts
@@ -62,7 +75,7 @@ function fromKubeconfig(kubeconfig, current) {
   let insecureSkipTlsVerify = false;
   if (cluster) {
     if (cluster['certificate-authority']) {
-      ca = fs.readFileSync(path.normalize(cluster['certificate-authority']));
+      ca = fs.readFileSync(normalizePath(cluster['certificate-authority']));
     } else if (cluster['certificate-authority-data']) {
       ca = Buffer.from(cluster['certificate-authority-data'], 'base64').toString();
     }
@@ -77,13 +90,13 @@ function fromKubeconfig(kubeconfig, current) {
   const auth = {};
   if (user) {
     if (user['client-certificate']) {
-      cert = fs.readFileSync(path.normalize(user['client-certificate']));
+      cert = fs.readFileSync(normalizePath(user['client-certificate']));
     } else if (user && user['client-certificate-data']) {
       cert = Buffer.from(user['client-certificate-data'], 'base64').toString();
     }
 
     if (user['client-key']) {
-      key = fs.readFileSync(path.normalize(user['client-key']));
+      key = fs.readFileSync(normalizePath(user['client-key']));
     } else if (user['client-key-data']) {
       key = Buffer.from(user['client-key-data'], 'base64').toString();
     }
@@ -114,10 +127,7 @@ function fromKubeconfig(kubeconfig, current) {
 module.exports.fromKubeconfig = fromKubeconfig;
 
 function loadKubeconfig(cfgPath) {
-  cfgPath = cfgPath || path.join(
-    process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'],
-    '.kube',
-    'config');
+  cfgPath = cfgPath || defaultConfigPath();
   return yaml.safeLoad(fs.readFileSync(cfgPath));
 }
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -4,6 +4,7 @@
 const assume = require('assume');
 const sinon = require('sinon');
 const fs = require('fs');
+const yaml = require('js-yaml');
 
 const config = require('../lib/config');
 
@@ -128,6 +129,70 @@ describe('Config', () => {
       assume(args.ca).equals('certificate-authority-data');
       assume(args.key).equals('client-key');
       assume(args.cert).equals('client-certificate');
+    });
+
+    it('handles relative certs and keys', () => {
+      const kubeconfig = {
+        'apiVersion': 'v1',
+        'kind': 'Config',
+        'preferences': {},
+        'current-context': 'foo-context',
+        'contexts': [
+          {
+            name: 'foo-context',
+            context: {
+              cluster: 'foo-cluster',
+              user: 'foo-user'
+            }
+          }
+        ],
+        'clusters': [
+          {
+            name: 'foo-cluster',
+            cluster: {
+              'certificate-authority': 'ca.pem',
+              'server': 'https://192.168.42.121:8443'
+            }
+          }
+        ],
+        'users': [
+          {
+            name: 'foo-user',
+            user: {
+              'client-certificate': 'client.cert',
+              'client-key': 'client.key'
+            }
+          }
+        ]
+      };
+
+      const fsReadFileSync = sandbox.stub(fs, 'readFileSync');
+      const yamlSafeLoad = sandbox.stub(yaml, 'safeLoad');
+
+      fsReadFileSync
+        .withArgs(sinon.match(/config$/))
+        .returns('mock-config');
+
+      fsReadFileSync
+        .withArgs(sinon.match('/ca.pem'))
+        .returns('certificate-authority-data');
+
+      fsReadFileSync
+        .withArgs(sinon.match('/client.key'))
+        .returns('client-key-data');
+
+      fsReadFileSync
+        .withArgs(sinon.match('/client.cert'))
+        .returns('client-certificate-data');
+
+      yamlSafeLoad
+        .withArgs('mock-config')
+        .returns(kubeconfig);
+
+      const args = config.fromKubeconfig();
+      assume(args.ca).equals('certificate-authority-data');
+      assume(args.key).equals('client-key-data');
+      assume(args.cert).equals('client-certificate-data');
     });
 
     it('handles token', () => {


### PR DESCRIPTION
Our configuration uses relative certificate settings. It is working very well with the `kubectl` command but `kubernetes-client` does not support relative certificates.

Unfortunately the current API does not work very well with this setup because the path of the current config file is not available only in the default case. I fixed the default config handling to make it work but I know it isn't entirely right.

I am open to other solutions or recommendations.