### PR TITLE
refactor(request): move REST request code to it's own file.

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const assign = require('assign-deep');
-const request = require('request');
 const aliasResources = require('./common').aliasResources;
 const BaseObject = require('./base');
 const Namespaces = require('./namespaces');
+const Request = require('./request');
 
 class ApiGroup {
   /**
@@ -23,19 +23,19 @@ class ApiGroup {
     this.url = options.url;
     this.version = options.version;
     this.path = `/${ options.path }/${ this.version }`;
-    this.requestOptions = options.request || {};
 
-    this.requestOptions.ca = options.ca;
-    this.requestOptions.cert = options.cert;
-    this.requestOptions.key = options.key;
-
+    const requestOptions = options.request || {};
+    requestOptions.url = options.url;
+    requestOptions.ca = options.ca;
+    requestOptions.cert = options.cert;
+    requestOptions.key = options.key;
     if ('insecureSkipTlsVerify' in options) {
-      this.requestOptions.strictSSL = !options.insecureSkipTlsVerify;
+      requestOptions.insecureSkipTlsVerify = options.insecureSkipTlsVerify;
     }
-
     if (options.auth) {
-      this.requestOptions.auth = options.auth;
+      requestOptions.auth = options.auth;
     }
+    this.http = new Request(requestOptions);
 
     this.resourceConfig = {
       promises: options.promises
@@ -85,57 +85,13 @@ class ApiGroup {
   }
 
   /**
-   * Return a full Kuberentes API path (including the version)
-   * @param {string} path - version-less path
-   * @returns {string} Full Kuberentes API path
-   */
-  _url(path) {
-    path = typeof path === 'string' ? path : path.join('/');
-    return `${ this.url }${ path }`;
-  }
-
-  /**
-   * @typedef {object} ApiRequestOptions
-   * @property {object} body - Request body
-   * @property {object} headers - Headers object
-   * @property {string} path - version-less path
-   * @property {object} qs - {@link https://www.npmjs.com/package/request#requestoptions-callback|
-   *                          request query parameter}
-   */
-
-  /**
-   * Invoke a REST request against the Kubernetes API server
-   * @param {string} method - HTTP method, passed directly to `request`
-   * @param {ApiRequestOptions} options - Options object
-   * @param {callback} cb - The callback that handles the response
-   * @returns {Stream} If cb is falsy, return a stream
-   */
-  _request(method, options, cb) {
-    const requestOptions = Object.assign({
-      method: method || 'GET',
-      uri: this._url(options.path),
-      body: options.body,
-      json: true,
-      qs: options.qs,
-      headers: options.headers
-    }, this.requestOptions);
-
-    if (typeof cb !== 'function') return request(requestOptions);
-
-    return request(requestOptions, (err, res, body) => {
-      if (err) return cb(err);
-      cb(null, { statusCode: res.statusCode, body: body });
-    });
-  }
-
-  /**
    * Invoke a GET request against the Kubernetes API server
    * @param {ApiRequestOptions} options - Options object.
    * @param {callback} cb - The callback that handles the response
    * @returns {Stream} If cb is falsy, return a stream
    */
   get(options, cb) {
-    return this._request('GET', options, cb);
+    return this.http.request('GET', options, cb);
   }
 
   /**
@@ -144,7 +100,7 @@ class ApiGroup {
    * @param {callback} cb - The callback that handles the response
    */
   delete(options, cb) {
-    this._request('DELETE', options, cb);
+    this.http.request('DELETE', options, cb);
   }
 
   /**
@@ -153,7 +109,7 @@ class ApiGroup {
    * @param {callback} cb - The callback that handles the response
    */
   patch(options, cb) {
-    this._request('PATCH', assign({
+    this.http.request('PATCH', assign({
       headers: { 'content-type': 'application/strategic-merge-patch+json' }
     }, options), cb);
   }
@@ -164,7 +120,7 @@ class ApiGroup {
    * @param {callback} cb - The callback that handles the response
    */
   post(options, cb) {
-    this._request('POST', assign({
+    this.http.request('POST', assign({
       headers: { 'content-type': 'application/json' }
     }, options), cb);
   }
@@ -175,7 +131,7 @@ class ApiGroup {
    * @param {callback} cb - The callback that handles the response
    */
   put(options, cb) {
-    this._request('PUT', assign({
+    this.http.request('PUT', assign({
       headers: { 'content-type': 'application/json' }
     }, options), cb);
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,0 +1,56 @@
+const request = require('request');
+
+class Request {
+  constructor(options) {
+    this.requestOptions = options.request || {};
+    this.requestOptions.baseUrl = options.url;
+    this.requestOptions.ca = options.ca;
+    this.requestOptions.cert = options.cert;
+    this.requestOptions.key = options.key;
+
+    if ('insecureSkipTlsVerify' in options) {
+      this.requestOptions.strictSSL = !options.insecureSkipTlsVerify;
+    }
+
+    if (options.auth) {
+      this.requestOptions.auth = options.auth;
+    }
+  }
+
+  /**
+   * @typedef {object} ApiRequestOptions
+   * @property {object} body - Request body
+   * @property {object} headers - Headers object
+   * @property {string} path - version-less path
+   * @property {object} qs - {@link https://www.npmjs.com/package/request#requestoptions-callback|
+   *                          request query parameter}
+   */
+
+  /**
+   * Invoke a REST request against the Kubernetes API server
+   * @param {string} method - HTTP method, passed directly to `request`
+   * @param {ApiRequestOptions} options - Options object
+   * @param {callback} cb - The callback that handles the response
+   * @returns {Stream} If cb is falsy, return a stream
+   */
+  request(method, options, cb) {
+    const uri = typeof options.path === 'string' ? options.path : options.path.join('/');
+    const requestOptions = Object.assign({
+      method: method,
+      uri: uri,
+      body: options.body,
+      json: true,
+      qs: options.qs,
+      headers: options.headers
+    }, this.requestOptions);
+
+    if (typeof cb !== 'function') return request(requestOptions);
+
+    return request(requestOptions, (err, res, body) => {
+      if (err) return cb(err);
+      cb(null, { statusCode: res.statusCode, body: body });
+    });
+  }
+}
+
+module.exports = Request;

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const request = require('request');
 
 class Request {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -614,8 +624,8 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.1.1",
@@ -2074,16 +2084,6 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsprim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
@@ -3264,6 +3264,17 @@
         }
       }
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
     "string_decoder": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
@@ -3279,17 +3290,6 @@
           "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
           "dev": true
         }
-      }
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
       }
     },
     "stringstream": {


### PR DESCRIPTION
This refactor isn't useful by itself, but is part of the larger effort to
generate API clients based on swagger docs:

https://github.com/godaddy/kubernetes-client/issues/129

Forthcoming PRs will leverage this change.