### PR TITLE
Add NamespaceList v1 core enumeration

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -44,7 +44,7 @@ class ApiGroup {
     //
     // Create the default namespace so we have it directly on the API
     //
-    this.namespaces = new Namespaces({
+    this.namespace = new Namespaces({
       api: this,
       parentPath: this.path,
       namespace: options.namespace,

--- a/lib/common.js
+++ b/lib/common.js
@@ -19,7 +19,7 @@ module.exports.aliasResources = function (resourceObject) {
     ingresses: ['ing'],
     jobs: [],
     limitranges: ['limits'],
-    namespaces: ['ns'],
+    namespace: ['ns'],
     nodes: ['no'],
     persistentvolumes: ['pv'],
     persistentvolumeclaims: ['pvc'],

--- a/lib/core.js
+++ b/lib/core.js
@@ -17,7 +17,8 @@ class Core extends ApiGroup {
       'resourcequotas',
       'secrets',
       'serviceaccounts',
-      'services'
+      'services',
+      'namespaces'
     ];
     options = Object.assign({}, options, {
       path: 'api',


### PR DESCRIPTION
This was achieved by adding the string 'namespaces' to groupResources in core.js. Thus Accessing NamespaceList v1 core api
can be easily done using
`core.namespaces.get(print);`.
To maintain previous functionality I renamed the default namespace (directly on the API) to `namespace`
(single instead of plural) and updated the alias ns.  Thus accessing deployments on a given NAMESPACE can be done using
`ext.namespace(NAMESPACE).deployments('').get(print);`