### PR TITLE
fix(namespaces): api.namespaces('foo') usage

### DIFF
--- a/lib/custom-resource-definitions.js
+++ b/lib/custom-resource-definitions.js
@@ -18,7 +18,7 @@ class CustomResourceDefinition extends ApiGroup {
   }
 
   addResource(resourceName) {
-    this.namespace.addResource(resourceName);
+    this.namespace.addNamedResource(resourceName);
     super.addResource(resourceName);
     return this;
   }

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -4,6 +4,23 @@ const async = require('async');
 
 const aliasResources = require('./common').aliasResources;
 const BaseObject = require('./base');
+const ContainerBaseObject = require('./container-base-object');
+
+class NamedNamespaces extends ContainerBaseObject {
+  constructor(options) {
+    super(options);
+    aliasResources(this);
+  }
+
+  /**
+   * Return the API object for the given Kubernetes kind
+   * @param {object|string} k - Kubernetes manifest object or a string
+   * @returns {BaseObject} Kubernetes API object.
+   */
+  kind(k) {
+    return this[(k.kind || k).toLowerCase()];
+  }
+}
 
 class Namespaces extends BaseObject {
   /**
@@ -15,30 +32,21 @@ class Namespaces extends BaseObject {
    * @param {string} options.path - Optional path of this resource
    */
   constructor(options) {
-    const api = options.api;
-    const parentPath = options.parentPath;
-    const call = name => {
-      return new this.constructor({
-        api: api,
-        namespace: name,
-        parentPath: parentPath,
-        resources: this.resources
-      });
-    };
+    super(Object.assign({}, options, {
+      fn: name => new NamedNamespaces({
+        api: options.api,
+        name: name,
+        parentPath: this.path,
+        resources: this.namedResources
+      }),
+      name: options.name || 'namespaces'
+    }));
+    this.namedResources = options.resources.slice();
+  }
 
-    super(Object.assign({
-      api: api,
-      fn: call,
-      name: 'namespaces',
-      parentPath: parentPath
-    }, options));
-
-    this.namespace = options.namespace || 'default';
-
-    this.resources = [];
-    options.resources.forEach(resource => this.addResource(resource));
-
-    aliasResources(this);
+  addNamedResource(options) {
+    this.namedResources.push(options);
+    return this;
   }
 
   _wait(options, cb) {
@@ -54,20 +62,6 @@ class Namespaces extends BaseObject {
         next(new Error('Waiting for namespace removal'));
       });
     }, cb);
-  }
-
-  addResource(options) {
-    if (typeof options === 'string') {
-      options = { name: options, Constructor: BaseObject };
-    }
-    const resourceOptions = {
-      api: this.api,
-      name: options.name,
-      parentPath: `${ this.path }/${ this.namespace }`
-    };
-    this[options.name] = new options.Constructor(resourceOptions);
-    this.resources.push(Object.assign({}, options));
-    return this;
   }
 
   /**
@@ -90,15 +84,6 @@ class Namespaces extends BaseObject {
         uid: result.metadata.uid
       }, waitErr => cb(waitErr, result));
     });
-  }
-
-  /**
-   * Return the API object for the given Kubernetes kind
-   * @param {object|string} k - Kubernetes manifest object or a string
-   * @returns {BaseObject} Kubernetes API object.
-   */
-  kind(k) {
-    return this[(k.kind || k).toLowerCase()];
   }
 }
 

--- a/lib/third-party-resources.js
+++ b/lib/third-party-resources.js
@@ -18,7 +18,7 @@ class ThirdPartyResource extends ApiGroup {
   }
 
   addResource(resourceName) {
-    this.namespace.addResource(resourceName);
+    this.namespace.addNamedResource(resourceName);
     super.addResource(resourceName);
     return this;
   }

--- a/test/api-group.test.js
+++ b/test/api-group.test.js
@@ -97,7 +97,7 @@ describe('lib.api-group', () => {
 
     it('GETs', done => {
       async.series([
-        next => { common.apiGroup.group(ingress()).ns.kind(ingress()).get(next); }
+        next => { common.apiGroup.group(ingress()).ns(common.currentName).kind(ingress()).get(next); }
       ], err => {
         assume(err).is.falsy();
         done();

--- a/test/apps.test.js
+++ b/test/apps.test.js
@@ -75,8 +75,8 @@ describe('lib.apps', () => {
 
     it('can POST and GET', done => {
       async.series([
-        next => common.apps.ns.statefulsets.post({ body: testStatefulSet }, next),
-        next => common.apps.ns.statefulsets.get(testStatefuleSetName, next)
+        next => common.apps.ns(common.currentName).statefulsets.post({ body: testStatefulSet }, next),
+        next => common.apps.ns(common.currentName).statefulsets.get(testStatefuleSetName, next)
       ], (err, results) => {
         assume(err).is.falsy();
         const getResult = results[1];
@@ -100,8 +100,8 @@ describe('lib.apps', () => {
 
     it('can POST and GET', done => {
       async.series([
-        next => common.apps.ns.deployments.post({ body: testDeployment }, next),
-        next => common.apps.ns.deployments.get(testDeploymentName, next)
+        next => common.apps.ns(common.currentName).deployments.post({ body: testDeployment }, next),
+        next => common.apps.ns(common.currentName).deployments.get(testDeploymentName, next)
       ], (err, results) => {
         assume(err).is.falsy();
         const getResult = results[1];

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -57,10 +57,11 @@ describe('lib.base', () => {
       beforeTesting('int', done => {
         common.changeName(err => {
           assume(err).is.falsy();
+          const po = common.api.ns(common.currentName).po;
           async.each([
             { body: pod('pod0') },
             { body: pod('pod1') }
-          ], common.api.ns.po.post.bind(common.api.ns.po), done);
+          ], po.post.bind(po), done);
         });
       });
       beforeTesting('unit', () => {
@@ -76,7 +77,7 @@ describe('lib.base', () => {
       });
 
       it('GETs with labelSelector', done => {
-        common.api.ns.po.match([{
+        common.api.ns(common.currentName).po.match([{
           key: 'name',
           operator: 'In',
           values: ['pod0']
@@ -117,11 +118,11 @@ describe('lib.base', () => {
           });
       });
       beforeTesting('int', done => {
-        common.api.ns.po.post({ body: pod(podName) }, done);
+        common.api.ns(common.currentName).po.post({ body: pod(podName) }, done);
       });
 
       it('should bypass query string and body from arguments into request', done => {
-        common.api.ns.po.delete({ name: podName, qs: query, body: body }, (err, result) => {
+        common.api.ns(common.currentName).po.delete({ name: podName, qs: query, body: body }, (err, result) => {
           assume(err).is.falsy();
           assume(result.kind).is.eql('Pod');
           assume(result.metadata).is.truthy();
@@ -137,10 +138,11 @@ describe('lib.base', () => {
       beforeTesting('int', done => {
         common.changeName(err => {
           assume(err).is.falsy();
+          const po = common.api.ns(common.currentName).po;
           async.each([
             { body: pod('pod0') },
             { body: pod('pod1') }
-          ], common.api.ns.po.post.bind(common.api.ns.po), done);
+          ], po.post.bind(po), done);
         });
       });
       beforeTesting('unit', () => {
@@ -156,7 +158,7 @@ describe('lib.base', () => {
       });
 
       it('GETs with labelSelector', done => {
-        common.api.ns.po.matchLabels({
+        common.api.ns(common.currentName).po.matchLabels({
           name: 'pod0',
           service: 'service1'
         }).get((err, pods) => {
@@ -173,7 +175,7 @@ describe('lib.base', () => {
     beforeTesting('int', done => {
       common.changeName(err => {
         assume(err).is.falsy();
-        common.api.ns.pvc.post({ body: testPvc }, done);
+        common.api.ns(common.currentName).pvc.post({ body: testPvc }, done);
       });
     });
     beforeTesting('unit', () => {
@@ -189,7 +191,7 @@ describe('lib.base', () => {
     });
 
     it('GETs with labelSelector', done => {
-      common.api.ns.pvc.matchLabels({
+      common.api.ns(common.currentName).pvc.matchLabels({
         app: 'test'
       }).get((err, pvcs) => {
         assume(err).is.falsy();

--- a/test/batch.test.js
+++ b/test/batch.test.js
@@ -47,8 +47,8 @@ describe('lib.batch', () => {
 
     it('can POST and GET', done => {
       async.series([
-        next => common.batch.ns.jobs.post({ body: testJob }, next),
-        next => common.batch.ns.jobs.get(testJobName, next)
+        next => common.batch.ns(common.currentName).jobs.post({ body: testJob }, next),
+        next => common.batch.ns(common.currentName).jobs.get(testJobName, next)
       ], (err, results) => {
         assume(err).is.falsy();
         const getResult = results[1];

--- a/test/common.js
+++ b/test/common.js
@@ -146,7 +146,7 @@ function changeNameInt(cb) {
     const times = Math.ceil(defaultTimeout / 1000);
     const interval = 1000;
     async.retry({ times: times, interval: interval }, next => {
-      module.exports.api.ns.serviceaccounts.get('default', (saErr, sa) => {
+      module.exports.api.ns(currentName).serviceaccounts.get('default', (saErr, sa) => {
         if (saErr) return next(saErr);
         if (!sa.secrets) {
           return next(new Error('Waiting for servicesaccount secrets'));

--- a/test/custom-resource-definition.test.js
+++ b/test/custom-resource-definition.test.js
@@ -68,7 +68,7 @@ describe('lib.CustomResourceDefinition', () => {
     only('unit', 'adds a BaseObject globally and to default namespace', () => {
       common.customResourceDefinitions.addResource('newresources');
       assume(common.customResourceDefinitions.newresources).is.truthy();
-      assume(common.customResourceDefinitions.namespace.newresources).is.truthy();
+      assume(common.customResourceDefinitions.ns(common.currentName).newresources).is.truthy();
     });
   });
 
@@ -107,12 +107,12 @@ describe('lib.CustomResourceDefinition', () => {
 
       it('creates a resources', done => {
         common.customResourceDefinitions
-          .ns
+          .ns(common.currentName)
           .newresources
           .post({ body: testManifest }, postErr => {
             assume(postErr).is.falsy();
             common.customResourceDefinitions
-              .ns
+              .ns(common.currentName)
               .newresources
               .get('test', (err, result) => {
                 assume(err).is.falsy();

--- a/test/deployments.test.js
+++ b/test/deployments.test.js
@@ -58,10 +58,10 @@ describe('lib.deployments', () => {
   it('POSTs, GETs, and DELETEs', done => {
     async.series([
       next => {
-        common.extensions.ns.deployments.post({ body: deploymentObj }, next);
+        common.extensions.ns(common.currentName).deployments.post({ body: deploymentObj }, next);
       },
-      next => common.extensions.ns.deployments.get(resourceName, next),
-      next => common.extensions.ns.deployments.delete(resourceName, next)
+      next => common.extensions.ns(common.currentName).deployments.get(resourceName, next),
+      next => common.extensions.ns(common.currentName).deployments.delete(resourceName, next)
     ], (err, results) => {
       assume(err).is.falsy();
       const deployments = results[0];
@@ -84,7 +84,7 @@ describe('lib.deployments', () => {
 
     it('returns DeploymentList', done => {
       async.series([
-        next => common.extensions.ns.deployments.get(next)
+        next => common.extensions.ns(common.currentName).deployments.get(next)
       ], (err, results) => {
         assume(err).is.falsy();
         const deploymentList = results[0];
@@ -111,7 +111,7 @@ describe('lib.deployments', () => {
     beforeTesting('int', done => {
       common.changeName(err => {
         assume(err).is.falsy();
-        common.extensions.ns.deployments.post({ body: deploymentObj }, postErr => {
+        common.extensions.ns(common.currentName).deployments.post({ body: deploymentObj }, postErr => {
           assume(postErr).is.falsy();
           done();
         });
@@ -119,7 +119,7 @@ describe('lib.deployments', () => {
     });
 
     it('returns Deployment with status', done => {
-      common.extensions.ns.deployments(resourceName).status.get((err, deployment) => {
+      common.extensions.ns(common.currentName).deployments(resourceName).status.get((err, deployment) => {
         assume(err).is.falsy();
         assume(deployment.kind).is.equal('Deployment');
         assume(deployment.status).is.a('object');

--- a/test/extensions.test.js
+++ b/test/extensions.test.js
@@ -57,10 +57,10 @@ describe('lib.extensions', () => {
     it('POSTs, GETs, and DELETEs', done => {
       async.series([
         next => {
-          common.extensions.ns.ds.post({ body: daemonSetObj }, next);
+          common.extensions.ns(common.currentName).ds.post({ body: daemonSetObj }, next);
         },
-        next => common.extensions.ns.ds.get(resourceName, next),
-        next => common.extensions.ns.ds.delete(resourceName, next)
+        next => common.extensions.ns(common.currentName).ds.get(resourceName, next),
+        next => common.extensions.ns(common.currentName).ds.delete(resourceName, next)
       ], (err, results) => {
         assume(err).is.falsy();
         const ds = results[0];
@@ -84,7 +84,7 @@ describe('lib.extensions', () => {
 
       it('returns DaemonSetList', done => {
         async.series([
-          next => common.extensions.ns.ds.get(next)
+          next => common.extensions.ns(common.currentName).ds.get(next)
         ], (err, results) => {
           assume(err).is.falsy();
           const dsList = results[0];

--- a/test/namespaces.test.js
+++ b/test/namespaces.test.js
@@ -13,17 +13,17 @@ describe('lib.namespaces', () => {
       const namespace = 'notdefault';
       const namespaces = new Namespaces({ api, parentPath, namespace, resources: [] });
       namespaces
-        .addResource('balonies')
-        .addResource('ducks');
-      assume(namespaces.balonies.constructor.name).is.equal('BaseObject');
-      assume(namespaces.ducks.constructor.name).is.equal('BaseObject');
+        .addNamedResource('balonies')
+        .addNamedResource('ducks');
+      assume(namespaces('foo').balonies.constructor.name).is.equal('BaseObject');
+      assume(namespaces('foo').ducks.constructor.name).is.equal('BaseObject');
     });
 
     it('ensures named namespaces inherit resources', () => {
       const parentPath = '/apis/foo.com/v1';
       const namespace = 'notdefault';
       const namespaces = new Namespaces({ api, parentPath, namespace, resources: [] });
-      namespaces.addResource('balonies');
+      namespaces.addNamedResource('balonies');
       const namespacesFoo = namespaces('foo');
       assume(namespacesFoo.balonies.constructor.name).is.equal('BaseObject');
     });

--- a/test/objects.test.js
+++ b/test/objects.test.js
@@ -123,7 +123,7 @@ describe('objects', function () {
     });
 
     it('creates a ReplicationController', function (done) {
-      common.api.ns.rc.post({ body: testReplicationController }, (err, result) => {
+      common.api.ns(common.currentName).rc.post({ body: testReplicationController }, (err, result) => {
         assume(err).is.falsy();
         assume(result.metadata.name).is.equal('test-rc');
         done();
@@ -135,7 +135,7 @@ describe('objects', function () {
     beforeTesting('int', done => {
       common.changeName(err => {
         assume(err).is.falsy();
-        common.api.ns.rc.post({ body: testReplicationController }, done);
+        common.api.ns(common.currentName).rc.post({ body: testReplicationController }, done);
       });
     });
     beforeTesting('unit', () => {
@@ -144,7 +144,7 @@ describe('objects', function () {
         .reply(200, testReplicationController);
     });
     it('PUTs the new manifest', function (done) {
-      common.api.ns.rc.put({ name: 'test-rc', body: testReplicationController }, (err, result) => {
+      common.api.ns(common.currentName).rc.put({ name: 'test-rc', body: testReplicationController }, (err, result) => {
         assume(err).is.falsy();
         assume(result.metadata.name).is.equal('test-rc');
         done();

--- a/test/pods.test.js
+++ b/test/pods.test.js
@@ -58,7 +58,7 @@ describe('lib.pods', () => {
     });
 
     it('succeeds creating a new pod', done => {
-      common.api.ns.pods.post({ body: testPod }, (err, pod) => {
+      common.api.ns(common.currentName).pods.post({ body: testPod }, (err, pod) => {
         assume(err).is.falsy();
         assume(pod.metadata.name).is.equal('test-pod');
         done();
@@ -71,7 +71,7 @@ describe('lib.pods', () => {
       beforeTesting('int', done => {
         common.changeName(err => {
           assume(err).is.falsy();
-          common.api.ns.pods.post({ body: testPod }, postErr => {
+          common.api.ns(common.currentName).pods.post({ body: testPod }, postErr => {
             assume(postErr).is.falsy();
             done();
           });
@@ -84,7 +84,7 @@ describe('lib.pods', () => {
       });
 
       it('succeeds at updating a pod', done => {
-        common.api.ns.pods('test-pod').patch({ body: testStrategicMergePatch }, (err, pod) => {
+        common.api.ns(common.currentName).pods('test-pod').patch({ body: testStrategicMergePatch }, (err, pod) => {
           assume(err).is.falsy();
           assume(pod.metadata.name).is.equal('test-pod');
           assume(pod.spec.containers[0].image).is.equal('still-does-not-matter:latest');
@@ -97,7 +97,7 @@ describe('lib.pods', () => {
       beforeTesting('int', done => {
         common.changeName(err => {
           assume(err).is.falsy();
-          common.api.ns.pods.post({ body: testPod }, postErr => {
+          common.api.ns(common.currentName).pods.post({ body: testPod }, postErr => {
             assume(postErr).is.falsy();
             done();
           });
@@ -117,7 +117,7 @@ describe('lib.pods', () => {
       });
 
       it('succeeds at updating a pod', done => {
-        common.api.ns.pods('test-pod').patch({
+        common.api.ns(common.currentName).pods('test-pod').patch({
           body: testMergePatch,
           headers: { 'content-type': 'application/merge-patch+json' }
         }, (err, pod) => {
@@ -129,7 +129,7 @@ describe('lib.pods', () => {
       });
 
       only('int', 'fails at updating a pod if the patch is strategic', done => {
-        common.api.ns.pods('test-pod').patch({
+        common.api.ns(common.currentName).pods('test-pod').patch({
           body: testStrategicMergePatch,
           headers: { 'content-type': 'application/merge-patch+json' }
         }, err => {
@@ -144,7 +144,7 @@ describe('lib.pods', () => {
     beforeTesting('int', done => {
       common.changeName(err => {
         assume(err).is.falsy();
-        common.api.ns.pods.post({ body: testPod }, done);
+        common.api.ns(common.currentName).pods.post({ body: testPod }, done);
       });
     });
     beforeTestingEach('unit', () => {
@@ -156,14 +156,14 @@ describe('lib.pods', () => {
         });
     });
     it('returns the Pod', done => {
-      common.api.ns.pods('test-pod').get((err, pod) => {
+      common.api.ns(common.currentName).pods('test-pod').get((err, pod) => {
         assume(err).is.falsy();
         assume(pod.kind).is.equal('Pod');
         done();
       });
     });
     it('returns the Pod via a stream', done => {
-      const stream = common.api.ns.pods('test-pod').getStream();
+      const stream = common.api.ns(common.currentName).pods('test-pod').getStream();
       const pieces = [];
       stream.on('data', data => pieces.push(data.toString()));
       stream.on('error', err => assume(err).is.falsy());
@@ -174,7 +174,7 @@ describe('lib.pods', () => {
       });
     });
     only('unit', 'returns the Pod via the legacy method', done => {
-      common.api.ns.pods.get('test-pod', (err, pod) => {
+      common.api.ns(common.currentName).pods.get('test-pod', (err, pod) => {
         assume(err).is.falsy();
         assume(pod.kind).is.equal('Pod');
         done();
@@ -186,7 +186,7 @@ describe('lib.pods', () => {
     beforeTesting('int', done => {
       common.changeName(err => {
         assume(err).is.falsy();
-        common.api.ns.pods.post({ body: testPod }, done);
+        common.api.ns(common.currentName).pods.post({ body: testPod }, done);
       });
     });
     beforeTestingEach('unit', () => {
@@ -195,7 +195,7 @@ describe('lib.pods', () => {
         .reply(200, { kind: 'Pod' });
     });
     it('deletes the Pod', done => {
-      common.api.ns.pods('test-pod').delete((err, pod) => {
+      common.api.ns(common.currentName).pods('test-pod').delete((err, pod) => {
         assume(err).is.falsy();
         assume(pod.kind).is.equal('Pod');
         done();
@@ -210,14 +210,14 @@ describe('lib.pods', () => {
         .reply(200, 'some log contents');
     });
     only('unit', 'returns log contents', done => {
-      common.api.ns.pods('test-pod').log.get((err, contents) => {
+      common.api.ns(common.currentName).pods('test-pod').log.get((err, contents) => {
         assume(err).is.falsy();
         assume(contents).is.equal('some log contents');
         done();
       });
     });
     only('unit', 'returns log contents via legacy method', done => {
-      common.api.ns.pods.log('test-pod', (err, contents) => {
+      common.api.ns(common.currentName).pods.log('test-pod', (err, contents) => {
         assume(err).is.falsy();
         assume(contents).is.equal('some log contents');
         done();

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -19,7 +19,7 @@ describe('lib.promise', () => {
     });
 
     only('unit', '.get returns a Pod via a promise', done => {
-      const pods = common.core.ns.po('test-pod').get();
+      const pods = common.core.ns(common.currentName).po('test-pod').get();
       pods.then(object => {
         assume(object.kind).is.equal('Pod');
         assume(object.metadata.name).is.equal('test-pod');
@@ -27,7 +27,7 @@ describe('lib.promise', () => {
       });
     });
     only('unit', '.getStream returns the Pod via a stream', done => {
-      const stream = common.core.ns.po('test-pod').getStream();
+      const stream = common.core.ns(common.currentName).po('test-pod').getStream();
       const pieces = [];
       stream.on('data', data => pieces.push(data.toString()));
       stream.on('error', err => assume(err).is.falsy());

--- a/test/rbac.test.js
+++ b/test/rbac.test.js
@@ -37,8 +37,8 @@ describe('lib.rbac', () => {
     // improvements to our integration test harness to make this work well.
     common.only('unit', 'can POST and GET', done => {
       async.series([
-        next => common.rbac.ns.roles.post({ body: testRbac }, next),
-        next => common.rbac.ns.roles.get(testRbacName, next)
+        next => common.rbac.ns(common.currentName).roles.post({ body: testRbac }, next),
+        next => common.rbac.ns(common.currentName).roles.get(testRbacName, next)
       ], (err, results) => {
         assume(err).is.falsy();
         const getResult = results[1];

--- a/test/third-party-resources.test.js
+++ b/test/third-party-resources.test.js
@@ -56,7 +56,7 @@ describe('lib.ThirdPartyResource', () => {
     only('unit', 'adds a BaseObject globally and to default namespace', () => {
       common.thirdPartyResources.addResource('newresources');
       assume(common.thirdPartyResources.newresources).is.truthy();
-      assume(common.thirdPartyResources.namespace.newresources).is.truthy();
+      assume(common.thirdPartyResources.ns(common.currentName).newresources).is.truthy();
     });
   });
 
@@ -95,12 +95,12 @@ describe('lib.ThirdPartyResource', () => {
 
       it('creates a resources', done => {
         common.thirdPartyResources
-          .ns
+          .ns(common.currentName)
           .newresources
           .post({ body: testManifest }, postErr => {
             assume(postErr).is.falsy();
             common.thirdPartyResources
-              .ns
+              .ns(common.currentName)
               .newresources
               .get('test', (err, result) => {
                 assume(err).is.falsy();


### PR DESCRIPTION
Fixes #187

BREAKING CHANGE: Removes default namespace feature. With a default namespace,
`api.namespaces.get` is potentially ambiguous: get the default namespaces or
get all namespaces. Remove the default namespace to be consistent with other
code.