### PR TITLE
chore(ReplicationController): remove replicationcontrollers.pods feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,23 +250,6 @@ thirdPartyResources.addResource('newresources');  // Notice pluralization!
 thirdPartyResources.ns.newresources.get(print);
 ```
 
-### ReplicationController Pods
-
-kubernetes-client provides a shortcut for listing all Pods matching a
-ReplicationController selector:
-
-```js
-core.ns.rc.po.get(print);
-```
-
-kubernetes-client deletes all the Pods associated with a
-ReplicationController when it deletes the ReplicationController. You
-can preserve the Pods:
-
-```js
-core.ns.rc.delete({ name: 'http-rc', preservePods: true }, print);
-```
-
 ### Watching and streaming
 
 You can call `.getStream` to stream results. This is useful for watching:

--- a/lib/replicationcontrollers.js
+++ b/lib/replicationcontrollers.js
@@ -1,57 +1,6 @@
 'use strict';
 
-const aliasResources = require('./common').aliasResources;
 const BaseObject = require('./base');
-
-class ReplicationControllerPods extends BaseObject {
-  /**
-   * Create a ReplicationControllersPods Kubernetes API object representing the
-   * Pods associated with (or selected by) a ReplicationController
-   * @param {object} options - Options object
-   * @param {Api} options.api - API object
-   * @param {string} options.parentPath - Optional path of parent resource
-   * @param {string} options.path - Optional path of this resource
-   */
-  constructor(options) {
-    super(Object.assign({
-      name: 'pods',
-      parentPath: options.parentPath,
-      api: options.api
-    }, options));
-    this.rc = options.rc;
-    for (const unsupported of ['delete', 'put', 'patch']) {
-      delete this[unsupported];
-    }
-  }
-
-  /**
-   * Get Pods matching a ReplicationController's selector
-   * @param {RequestOptions|string} options - GET options, or resource name
-   * @param {callback} cb - The callback that handles the response
-   */
-  _get(options, cb) {
-    if (arguments.length < 2) {
-      throw new Error(
-        'GETing ReplicationController Pods requires options and cb arguments. ' +
-        'Use api.namsepaces.pods.get if you want to get all Pods in a Namespace.'
-      );
-    }
-
-    this.rc._get(options, (rcErr, rc) => {
-      if (rcErr) return cb(rcErr);
-
-      const selector = Object.keys(rc.spec.selector).map(
-        key => `${ key }=${ rc.spec.selector[key] }`).join(',');
-      super._get({
-        path: this.path,
-        qs: { labelSelector: selector }
-      }, (podsErr, pods) => {
-        if (podsErr) return cb(podsErr);
-        cb(null, { rc: rc, podList: pods });
-      });
-    });
-  }
-}
 
 class ReplicationControllers extends BaseObject {
   /**
@@ -67,12 +16,6 @@ class ReplicationControllers extends BaseObject {
   constructor(options) {
     super(Object.assign({}, options, {
       name: options.name || 'replicationcontrollers' }));
-    this.pods = new ReplicationControllerPods({
-      parentPath: options.parentPath,
-      api: options.api,
-      rc: this
-    });
-    aliasResources(this);
   }
 
   /**

--- a/test/objects.test.js
+++ b/test/objects.test.js
@@ -41,7 +41,6 @@ describe('objects', function () {
   const _url = 'http://mock.kube.api';
   const _ns = '/api/v1/namespaces/default';
   const _rcs = `${ _ns }/replicationcontrollers`;
-  const _pods = `${ _ns }/pods`;
 
   function rcs() {
     return new ReplicationControllers({
@@ -86,43 +85,6 @@ describe('objects', function () {
         assume(err).is.truthy();
         done();
       });
-    });
-  });
-
-  describe('.ReplicationControllers.po.get', function () {
-    function nock200() {
-      return nock(_url)
-        .get(`${ _rcs }/foo`)
-        .reply(200, {
-          kind: 'replicationcontroller',
-          metadata: {},
-          spec: {
-            selector: {
-              name: 'foo'
-            }
-          }
-        })
-        .get(`${ _pods }?labelSelector=name%3Dfoo`)
-        .reply(200, {
-          kind: 'podlist'
-        });
-    }
-    only('unit', 'GETs PodList', function (done) {
-      nock200();
-      rcs().po.get({ name: 'foo' }, (err, results) => {
-        assume(err).is.falsy();
-        const rc = results.rc;
-        const podList = results.podList;
-        assume(rc.kind).is.equal('replicationcontroller');
-        assume(podList.kind).is.equal('podlist');
-        done();
-      });
-    });
-    only('unit', 'throws Error if missing options', function () {
-      function testFn() {
-        rcs().po.get(() => { throw Error('Should not reach'); });
-      }
-      assume(testFn).throws();
     });
   });
 


### PR DESCRIPTION
BREAKING CHANGE: The convenience function for selecting replicationcontroller
pods doesn't follow the kubernetes-client API contract. We're removing it
because it's cumbersome to support with recent changes (*e.g.*, support for
promises and the swagger gen code).