### PR TITLE
feat(promises): if caller doesn't specify a callback, return a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,22 +71,9 @@ const core = new Api.Core(Api.config.fromKubeconfig());
 
 ### **Experimental** support for promises and async/await
 
-kubernetes-client exposes **experimental** support for promises via
-the `promises` option passed to API group constructors. The API is the
-same, except for the functions that previously took a callback
-(*e.g.*, `.get`). Those functions now return a promise.
-
-```js
-// Notice the promises: true
-const core = new Api.Core({
-  url: 'http://my-k8s-api-server.com',
-  version: 'v1',  // Defaults to 'v1'
-  promises: true,  // Enable promises
-  namespace: 'my-project' // Defaults to 'default'
-});
-```
-
-and then:
+kubernetes-client has **experimental** support for promises. If you
+omit callbacks an HTTP method function (*e.g.*, `.get`), it will
+return a promise.
 
 ```js
 core.namespaces.replicationcontrollers('http-rc').get()
@@ -97,13 +84,6 @@ or with `async/await`:
 
 ```js
 print(null, await core.namespaces.replicationcontrollers('http-rc').get());
-```
-
-You can invoke promise-based and callback-based functions explictly:
-
-```js
-print(null, await core.namespaces.replicationcontrollers('http-rc').getPromise());
-core.namespaces.replicationcontrollers('http-rc').getCb(print);
 ```
 
 ### Creating and updating

--- a/lib/base.js
+++ b/lib/base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const promisify = require('util.promisify');
+const promy = require('promy');
 
 const matchExpression = require('./match-expression');
 
@@ -76,10 +76,7 @@ class BaseObject extends CallableObject {
 
     const apiFunctions = ['delete', 'get', 'patch', 'post', 'put'];
     apiFunctions.forEach(func => {
-      this[`${ func }Promise`] = promisify(this[`_${ func }`].bind(this));
-      this[`${ func }Cb`] = this[`_${ func }`].bind(this);
-      if (this.api.resourceConfig.promises) this[func] = this[`${ func }Promise`];
-      else this[func] = this[`${ func }Cb`];
+      this[func] = promy(this[`_${ func }`].bind(this));
     });
   }
 
@@ -96,7 +93,7 @@ class BaseObject extends CallableObject {
       options = { name: options };
     }
     this.api.delete({ path: this._path(options), qs: options.qs, body: options.body },
-                    cb200(cb));
+      cb200(cb));
   }
 
   _path(options) {
@@ -154,7 +151,7 @@ class BaseObject extends CallableObject {
    */
   _post(options, cb) {
     this.api.post({ path: this._path(options), body: options.body },
-                  cb200(cb));
+      cb200(cb));
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "@types/node": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
-      "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.5.tgz",
+      "integrity": "sha512-DvC7bzO5797bkApgukxouHmkOdYN2D0yL5olw0RncDpXUa6n39qTVsUi/5g2QJjPgl8qn4zh+4h0sofNoWGLRg==",
       "dev": true
     },
     "JSONStream": {
@@ -827,15 +836,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
-    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -972,28 +972,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -1268,11 +1246,6 @@
       "integrity": "sha1-gBWtFJwQEaEWzbieukzBHZA5rdg=",
       "dev": true
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1311,11 +1284,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1491,14 +1459,6 @@
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "requires": {
-        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1691,16 +1651,6 @@
         "builtin-modules": "1.1.1"
       }
     },
-    "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -1752,14 +1702,6 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "1.0.1"
-      }
-    },
     "is-resolvable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
@@ -1777,11 +1719,6 @@
       "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
       "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-text-path": {
       "version": "1.0.1",
@@ -2125,9 +2062,9 @@
       }
     },
     "lolex": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
-      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
       "dev": true
     },
     "longest": {
@@ -2247,9 +2184,9 @@
       }
     },
     "mocha": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
+      "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -2300,24 +2237,16 @@
       "dev": true
     },
     "nise": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
-      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.4.tgz",
+      "integrity": "sha512-88mRtnp7IasemV4yO4mSicqJkiIYaRcnjCqnZ5Dx0J9jLa5IXKKrEw5USAX5yUrLSJHcfqu7JuY275F+E0CBqw==",
       "dev": true,
       "requires": {
-        "formatio": "1.2.0",
+        "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "1.6.0",
+        "lolex": "2.3.2",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-          "dev": true
-        }
       }
     },
     "nock": {
@@ -2406,20 +2335,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.0.2.tgz",
       "integrity": "sha1-qXiFtVPldetACevAm92psc0hl5o=",
       "dev": true
-    },
-    "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
-      }
     },
     "once": {
       "version": "1.4.0",
@@ -2643,6 +2558,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
+    },
+    "promy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/promy/-/promy-0.1.0.tgz",
+      "integrity": "sha1-/xnDlT4QdM8D8i8/MkXIW3xxXUA="
     },
     "propagate": {
       "version": "0.4.0",
@@ -2929,33 +2849,33 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.3.tgz",
-      "integrity": "sha512-c7u0ZuvBRX1eXuB4jN3BRCAOGiUTlM8SE3TxbJHrNiHUKL7wonujMOB6Fi1gQc00U91IscFORQHDga/eccqpbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.2.tgz",
+      "integrity": "sha512-BEa593xl+IkIc94nKo0O0LauQC/gQy8Gyv4DkzPwF/9DweC5phr1y+42zibCpn9abfkdHxt9r8AhD0R6u9DE/Q==",
       "dev": true,
       "requires": {
         "diff": "3.3.1",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.1",
-        "nise": "1.2.0",
-        "supports-color": "4.5.0",
-        "type-detect": "4.0.5"
+        "lolex": "2.3.2",
+        "nise": "1.2.4",
+        "supports-color": "5.1.0",
+        "type-detect": "4.0.8"
       },
       "dependencies": {
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
         },
         "type-detect": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-          "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
           "dev": true
         }
       }
@@ -3470,15 +3390,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "requires": {
-        "define-properties": "1.1.2",
-        "object.getownpropertydescriptors": "2.0.3"
-      }
     },
     "uuid": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "async": "^2.6.0",
     "js-yaml": "^3.10.0",
     "lodash.merge": "^4.6.0",
-    "request": "^2.83.0",
-    "util.promisify": "^1.0.0"
+    "promy": "^0.1.0",
+    "request": "^2.83.0"
   },
   "devDependencies": {
     "@types/node": "^9.4.2",

--- a/test/common.js
+++ b/test/common.js
@@ -87,8 +87,6 @@ function injectApis(options) {
   Object.keys(apis).forEach(apiName => {
     const api = apis[apiName];
     module.exports[apiName] = new (api.Constructor)(Object.assign({}, options, api.options));
-    module.exports[`${ apiName }Promise`] =
-      new (api.Constructor)(Object.assign({ promises: true }, options, api.options));
   });
 }
 
@@ -104,11 +102,11 @@ function changeNameInt(cb) {
       'config');
     const config = yaml.load(fs.readFileSync(configPath));
     const context = config
-          .contexts.find(item => item.name === process.env.CONTEXT).context;
+      .contexts.find(item => item.name === process.env.CONTEXT).context;
     const cluster = config
-          .clusters.find(item => item.name === context.cluster).cluster;
+      .clusters.find(item => item.name === context.cluster).cluster;
     const user = config
-          .users.find(item => item.name === context.user).user;
+      .users.find(item => item.name === context.user).user;
     url = cluster.server;
     ca = fs.readFileSync(cluster['certificate-authority']);
     cert = fs.readFileSync(user['client-certificate']);

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -19,7 +19,7 @@ describe('lib.promise', () => {
     });
 
     only('unit', '.get returns a Pod via a promise', done => {
-      const pods = common.corePromise.ns.po('test-pod').get();
+      const pods = common.core.ns.po('test-pod').get();
       pods.then(object => {
         assume(object.kind).is.equal('Pod');
         assume(object.metadata.name).is.equal('test-pod');
@@ -27,7 +27,7 @@ describe('lib.promise', () => {
       });
     });
     only('unit', '.getStream returns the Pod via a stream', done => {
-      const stream = common.corePromise.ns.po('test-pod').getStream();
+      const stream = common.core.ns.po('test-pod').getStream();
       const pieces = [];
       stream.on('data', data => pieces.push(data.toString()));
       stream.on('error', err => assume(err).is.falsy());


### PR DESCRIPTION
Resolves #189

BREAKING CHANGE: This removes the (deprecated) `request`-like behavior of
returning a stream when the caller omits a callback. Use `.getStream` (instead
of `.get` without a callback) to get a stream.