### PR TITLE
chore(pods.log): remove the deprecated `pods.log` function.

### DIFF
--- a/lib/pods.js
+++ b/lib/pods.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const util = require('util');
-
 const BaseObject = require('./base');
 const ContainerBaseObject = require('./container-base-object');
 
@@ -39,24 +37,6 @@ class Pods extends BaseObject {
       }),
       name: options.name || 'pods'
     }));
-
-    this.log = util.deprecate(
-      this.log.bind(this),
-      'pods.log is deprecated and will be removed in 4.0.0. ' +
-      'Use pods(name).log.get instead.');
-  }
-
-  /**
-   * @deprecated Will be removed in 4.0.0. Use pods(name).log.get instead.
-   * @param {RequestOptions|string} options - GET options, or resource name
-   * @param {callback} cb - The callback that handles the response
-   * @returns {Stream} If cb is falsy, return a Stream
-   */
-  log(options, cb) {
-    if (typeof options === 'string') options = { name: options };
-    return this.get(
-      Object.assign({}, options, { name: `${ options.name }/log` }),
-      cb);
   }
 }
 

--- a/test/pods.test.js
+++ b/test/pods.test.js
@@ -173,13 +173,6 @@ describe('lib.pods', () => {
         done();
       });
     });
-    only('unit', 'returns the Pod via the legacy method', done => {
-      common.api.ns(common.currentName).pods.get('test-pod', (err, pod) => {
-        assume(err).is.falsy();
-        assume(pod.kind).is.equal('Pod');
-        done();
-      });
-    });
   });
 
   describe('.delete', () => {
@@ -211,13 +204,6 @@ describe('lib.pods', () => {
     });
     only('unit', 'returns log contents', done => {
       common.api.ns(common.currentName).pods('test-pod').log.get((err, contents) => {
-        assume(err).is.falsy();
-        assume(contents).is.equal('some log contents');
-        done();
-      });
-    });
-    only('unit', 'returns log contents via legacy method', done => {
-      common.api.ns(common.currentName).pods.log('test-pod', (err, contents) => {
         assume(err).is.falsy();
         assume(contents).is.equal('some log contents');
         done();


### PR DESCRIPTION
BREAKING CHANGE: `pods.log` doesn't follow the kubernetes-client API
conventions. Replace uses of `pods.log('foo')` with `pods('foo').log.get()`.