### PR TITLE
Fix request options parsing in ApiGroup

### DIFF
--- a/lib/api-group.js
+++ b/lib/api-group.js
@@ -24,7 +24,8 @@ class ApiGroup {
     this.version = options.version;
     this.path = `/${ options.path }/${ this.version }`;
 
-    const requestOptions = options.request || {};
+    const requestOptions = {};
+    requestOptions.request = options.request || {};
     requestOptions.url = options.url;
     requestOptions.ca = options.ca;
     requestOptions.cert = options.cert;

--- a/test/api-group.test.js
+++ b/test/api-group.test.js
@@ -4,6 +4,7 @@ const assume = require('assume');
 const async = require('async');
 const nock = require('nock');
 
+const ApiGroup = require('../lib/api-group');
 const common = require('./common');
 const beforeTesting = common.beforeTesting;
 
@@ -15,6 +16,38 @@ function ingress() {
 }
 
 describe('lib.api-group', () => {
+  describe('.constructor', () => {
+    it('passes request options correctly', () => {
+      const apiGroup = new ApiGroup({
+        namespaceResources: [],
+        groupResources: [],
+        url: '127.0.0.1',
+        ca: 'testCA',
+        cert: 'testCert',
+        key: 'testKey',
+        insecureSkipTlsVerify: false,
+        request: {
+          timeout: 1000
+        },
+        auth: {
+          user: 'testUser',
+          pass: 'testPass'
+        }
+      });
+      assume(apiGroup).hasOwn('http');
+      assume(apiGroup.http).hasOwn('requestOptions');
+      assume(apiGroup.http.requestOptions).hasOwn('baseUrl', '127.0.0.1');
+      assume(apiGroup.http.requestOptions).hasOwn('ca', 'testCA');
+      assume(apiGroup.http.requestOptions).hasOwn('cert', 'testCert');
+      assume(apiGroup.http.requestOptions).hasOwn('key', 'testKey');
+      assume(apiGroup.http.requestOptions).hasOwn('strictSSL', true);
+      assume(apiGroup.http.requestOptions).hasOwn('timeout', 1000);
+      assume(apiGroup.http.requestOptions).hasOwn('auth');
+      assume(apiGroup.http.requestOptions.auth).hasOwn('user', 'testUser');
+      assume(apiGroup.http.requestOptions.auth).hasOwn('pass', 'testPass');
+    });
+  });
+
   describe('.ns', () => {
 
     let nameForTest;


### PR DESCRIPTION
The readme indicates that bare request options can be passed through when instantiating ApiGroup objects. It looks like there was a regression introduced with https://github.com/godaddy/kubernetes-client/pull/161. I've included a fix here, along with tests for all of the parameters defined in the docs.