### PR TITLE
chore(Node.js support): Drop support for Node.js 4 and 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
     - node_js: "8"
     - node_js: "7"
     - node_js: "6"
-    - node_js: "5"
-    - node_js: "4"
 before_install:
 - '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
 - npm install -g greenkeeper-lockfile@1

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "GoDaddy Operating Company, LLC",
   "license": "MIT",
   "engines": {
-    "node": ">=4.2.0"
+    "node": ">=6.0.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
BREAKING CHANGE: EOL for 4 is end of April (https://github.com/nodejs/Release).
We're dropping support a little early in order to leverage some 6+ features for
upcoming improvements (e.g., https://github.com/godaddy/kubernetes-client/pull/207)