### PR TITLE
Automatically load kubeconfig when its provided as a path to the file

### DIFF
--- a/examples/canary-controller.js
+++ b/examples/canary-controller.js
@@ -10,8 +10,8 @@
 //   $ kubectl expose deployment coalmine --type=NodePort --selector='app=coalmine,state=stable'
 //   $ minikube service coalmine --url
 //
-const Client = require('../lib').Client;
-const config = require('../lib').config;
+const Client = require('kubernetes-client').Client;
+const config = require('kubernetes-client').config;
 const JSONStream = require('json-stream');
 
 const namespace = 'default';

--- a/lib/config.js
+++ b/lib/config.js
@@ -53,7 +53,9 @@ module.exports.getInCluster = getInCluster;
 /* eslint-disable complexity, max-statements */
 function fromKubeconfig(kubeconfig, current) {
   if (!kubeconfig) kubeconfig = loadKubeconfig();
-
+  // if kubeconfig is provided as a path to the yaml file,
+  // automatically load it.
+  if (typeof kubeconfig === 'string') kubeconfig = loadKubeconfig(kubeconfig);
   current = current || kubeconfig['current-context'];
   const context = kubeconfig.contexts
     .find(item => item.name === current).context;

--- a/lib/config.js
+++ b/lib/config.js
@@ -56,6 +56,7 @@ function fromKubeconfig(kubeconfig, current) {
   // if kubeconfig is provided as a path to the yaml file,
   // automatically load it.
   if (typeof kubeconfig === 'string') kubeconfig = loadKubeconfig(kubeconfig);
+
   current = current || kubeconfig['current-context'];
   const context = kubeconfig.contexts
     .find(item => item.name === current).context;

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -403,5 +403,10 @@ describe('Config', () => {
       const args = config.fromKubeconfig(kubeconfig, 'foo-context-2');
       assume(args.url).equals('https://192.168.42.122:8443');
     });
+
+    it('load kubeconfig from provided path', () => {
+      const args = config.fromKubeconfig('./test/fixtures/kube-fixture.yml');
+      assume(args.url).equals('https://192.168.42.121:8443');
+    });
   });
 });

--- a/test/fixtures/kube-fixture.yml
+++ b/test/fixtures/kube-fixture.yml
@@ -18,3 +18,4 @@ users:
   user:
     client-certificate-data: foo-cert-data
     client-key-data: foo-cert-key
+

--- a/test/fixtures/kube-fixture.yml
+++ b/test/fixtures/kube-fixture.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: foo-auth-data
+    server: https://192.168.42.121:8443
+  name: foo-cluster-1
+contexts:
+- context:
+    cluster: foo-cluster-1
+    namespace: default
+    user: foo-user
+  name: foo-context-1
+current-context: foo-context-1
+kind: Config
+preferences: {}
+users:
+- name: foo-user
+  user:
+    client-certificate-data: foo-cert-data
+    client-key-data: foo-cert-key


### PR DESCRIPTION
Talked with @jcrugzz, we probably need a back patch for this fix (probably for version 4?) since `trimmer` is still using 3.x.x version.
