### PR TITLE
chore(travis): always use `npm install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ matrix:
     - node_js: "10"
     - node_js: "8"
     - node_js: "6"
+# https://github.com/greenkeeperio/greenkeeper-lockfile#npm
 before_install:
-- npm install -g greenkeeper-lockfile@1
-- greenkeeper-lockfile-update
+# package-lock.json was introduced in npm@5
+- '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
+- npm install -g greenkeeper-lockfile
+before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload
+install: npm install


### PR DESCRIPTION
Travis uses `npm ci` by default for pull request builds. npm ci won't work
with greenkeeper pull requests because:

> If dependencies in the package lock do not match those in
> package.json, npm ci will exit with an error, instead of updating the
> package lock.

Tell travis to run `npm install` instead.

https://github.com/greenkeeperio/greenkeeper-lockfile#npm