### PR TITLE
fix(kube-config): use KUBECONFIG env var if set

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,14 @@ const tokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token';
 const namespacePath = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
 
 function defaultConfigPath() {
+  if (process.env.KUBECONFIG) {
+    // From https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable
+    // KUBECONFIG can support multiple config files.
+    // If multiple config files in KUBECONFIG, then return the first one.
+    const delimiter = process.platform === 'win32' ? ';' : ':';
+    const configPaths = process.env.KUBECONFIG.split(delimiter);
+    return configPaths[0];
+  }
   const homeDir = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
   return path.join(homeDir, '.kube', 'config');
 }


### PR DESCRIPTION
**NOTE**
Do we eventually want to support multiple config files in the future?
https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#create-a-second-configuration-file