### PR TITLE
Fix missing addCustomResourceDefinition in type definitions, add support for /status and /scale CRD endpoints

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -68,6 +68,28 @@ class Root extends Component {
       };
     });
 
+    // Add status endpoint - see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#customresourcesubresourcestatus-v1beta1-apiextensions-k8s-io
+    if (manifest.spec.subresources && manifest.spec.subresources.status) {
+
+      const statusPath = `/apis/${ group }/${ version }${ namespace }/${ name }/{name}/status`;
+      spec.paths[statusPath] = ['get', 'put'].reduce((acc, method) => {
+        acc[method] = { operationId: `${ method }Template${ name }` };
+        return acc;
+      }, {});
+
+    }
+
+    // Add scale endpoints - see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#customresourcesubresourcescale-v1beta1-apiextensions-k8s-io
+    if (manifest.spec.subresources && manifest.spec.subresources.scale) {
+
+      const statusPath = `/apis/${ group }/${ version }${ namespace }/${ name }/{name}/scale`;
+      spec.paths[statusPath] = ['get', 'put'].reduce((acc, method) => {
+        acc[method] = { operationId: `${ method }Template${ name }` };
+        return acc;
+      }, {});
+
+    }
+
     this._addSpec(spec);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2012,8 +2011,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2414,7 +2412,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2591,8 +2588,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -3440,8 +3436,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",

--- a/scripts/templates/ts-interface.mustache
+++ b/scripts/templates/ts-interface.mustache
@@ -12,4 +12,5 @@
     {{method}}(options ?: {{parameterType}}): {{returnType}}
   {{/calls}}
     loadSpec(): Promise<Api>
+    addCustomResourceDefinition(schema: object): void
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5971,6 +5971,7 @@ declare namespace KubernetesClient {
     'version': Version
     // Calls
     loadSpec(): Promise<Api>
+    addCustomResourceDefinition(schema: object): void;
   }
 
   interface ApiClient {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5971,7 +5971,7 @@ declare namespace KubernetesClient {
     'version': Version
     // Calls
     loadSpec(): Promise<Api>
-    addCustomResourceDefinition(schema: object): void;
+    addCustomResourceDefinition(schema: object): void
   }
 
   interface ApiClient {


### PR DESCRIPTION
- Fix #334 - Add method `addCustomResourceDefinition` to the typings.
- Add `.../status` and `.../scale` endpoints to CRD swagger definition as specified in the Kubernetes API