### PR TITLE
handle optional kube config user exec properties

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -143,10 +143,15 @@ function fromKubeconfig(kubeconfig, current) {
 
     if (user.exec) {
       const env = {};
-      user.exec.env.forEach(variable => {
-        env[variable.name] = variable.value;
-      });
-      const args = user.exec.args.join(' ');
+      if (user.exec.env) {
+        user.exec.env.forEach(variable => {
+          env[variable.name] = variable.value;
+        });
+      }
+      let args = '';
+      if (user.exec.args) {
+        args = user.exec.args.join(' ');
+      }
       auth = {
         provider: {
           type: 'cmd',

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -429,6 +429,48 @@ describe('Config', () => {
       expect(args.auth.provider.config['cmd-env']).deep.equals({ [envKey]: envValue });
     });
 
+    it('handles user.exec without optional env and args', () => {
+      const command = 'foo-command';
+      const kubeconfig = {
+        'apiVersion': 'v1',
+        'kind': 'Config',
+        'preferences': {},
+        'current-context': 'foo-context',
+        'contexts': [
+          {
+            name: 'foo-context',
+            context: {
+              cluster: 'foo-cluster',
+              user: 'foo-user'
+            }
+          }
+        ],
+        'clusters': [
+          {
+            name: 'foo-cluster',
+            cluster: {
+              server: 'https://192.168.42.121:8443'
+            }
+          }
+        ],
+        'users': [
+          {
+            name: 'foo-user',
+            user: {
+              exec: {
+                command
+              }
+            }
+          }
+        ]
+      };
+      const args = config.fromKubeconfig(kubeconfig);
+      expect(args.auth.provider.type).equals('cmd');
+      expect(args.auth.provider.config['cmd-args']).equals('');
+      expect(args.auth.provider.config['cmd-path']).equals(command);
+      expect(args.auth.provider.config['cmd-env']).deep.equals({});
+    });
+
     it('handles manually specified current-context', () => {
       const kubeconfig = {
         'apiVersion': 'v1',


### PR DESCRIPTION
this fixes #350 by making sure `user.exec.env` and `user.exec.args` are defined before using them when creating a config with `user.exec`.