### PR TITLE
feat(config): add pathPrefix parameter to getInClusterMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="6.5.0"></a>
+# [6.5.0](https://github.com/godaddy/kubernetes-client/compare/6.4.0...6.5.0) (2018-11-21)
+
+
+### Features
+
+* **config:** add pathPrefix parameter to getInClusterMethod ([89a659d](https://github.com/godaddy/kubernetes-client/commit/89a659d))
+
+
+
 <a name="6.4.0"></a>
 # [6.4.0](https://github.com/godaddy/kubernetes-client/compare/6.3.0...6.4.0) (2018-11-12)
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,7 +30,7 @@ function defaultConfigPaths () {
 * @param {String} pathPrefix Prefixes the location of the loaded Configpath
 * @returns {Object} { url, cert, auth, namespace }
 */
-function getInCluster (pathPrefix = '')  {
+function getInCluster (pathPrefix = '') {
   const host = process.env.KUBERNETES_SERVICE_HOST
   const port = process.env.KUBERNETES_SERVICE_PORT
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -27,9 +27,10 @@ function defaultConfigPaths () {
 * and http://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod
 *
 * @function getInCluster
+* @param {String} pathPrefix Prefixes the location of the loaded Configpath
 * @returns {Object} { url, cert, auth, namespace }
 */
-function getInCluster () {
+function getInCluster (pathPrefix = '')  {
   const host = process.env.KUBERNETES_SERVICE_HOST
   const port = process.env.KUBERNETES_SERVICE_PORT
 
@@ -39,9 +40,9 @@ function getInCluster () {
       ' and KUBERNETES_SERVICE_PORT must be defined')
   }
 
-  const ca = fs.readFileSync(caPath, 'utf8')
-  const bearer = fs.readFileSync(tokenPath, 'utf8')
-  const namespace = fs.readFileSync(namespacePath, 'utf8')
+  const ca = fs.readFileSync(pathPrefix + caPath, 'utf8')
+  const bearer = fs.readFileSync(pathPrefix + tokenPath, 'utf8')
+  const namespace = fs.readFileSync(pathPrefix + namespacePath, 'utf8')
 
   return {
     url: `https://${host}:${port}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kubernetes-client",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "kubernetes-client",
-  "version": "6.4.0",
+  "name": "@nicolaischmid/kubernetes-client",
+  "version": "6.5.0",
   "description": "Simplified Kubernetes API client.",
   "main": "lib/index.js",
   "types": "./typings/index.d.ts",


### PR DESCRIPTION
When using telepresence.io all mounted volumes are prefixed by a dynamic path. So to use this client with telepresence and the automatic configuration loading
the loading path has to be prefixed with the current TELEPRESENCE_ROOT env var. This change accounts for the problem and lets the user define a custom path prefix