### PR TITLE
Fallback to old swagger.json endpoint

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -40,17 +40,19 @@ class Root extends Component {
     return new Promise((resolve, reject) => {
       return this.http.request('GET', { path: '/openapi/v2' }, (modernGETErr, modernGETRes) => {
         if (modernGETErr) return reject(modernGETErr)
-        if (modernGETRes.statusCode === 404) {
+        if (modernGETRes.statusCode !== 200) {
           return this.http.request('GET', { path: '/swagger.json' }, (legacyGETErr, legacyGETRes) => {
             if (legacyGETErr) return reject(legacyGETErr)
             if (legacyGETRes.statusCode !== 200) {
-              return reject(new Error(`Failed to get /swagger.json: ${legacyGETRes.statusCode}`))
+              if (modernGETRes.statusCode !== 404) {
+                return reject(new Error(`Failed to get /openapi/v2: ${modernGETRes.statusCode}`))
+              } else {
+                return reject(new Error(`Failed to get /swagger.json: ${legacyGETRes.statusCode}`))
+              }
             }
             this._addSpec(legacyGETRes.body)
             return resolve(this)
           })
-        } else if (modernGETRes.statusCode !== 200) {
-          return reject(new Error(`Failed to get /openapi/v2: ${modernGETRes.statusCode}`))
         }
         this._addSpec(modernGETRes.body)
         return resolve(this)

--- a/test/swagger-client.test.js
+++ b/test/swagger-client.test.js
@@ -111,6 +111,18 @@ describe('lib.swagger-client', () => {
           nock(common.api.url)
             .get('/openapi/v2')
             .reply(500, 'Internal Error')
+
+          nock(common.api.url)
+            .get('/swagger.json')
+            .reply(500, {
+              paths: {
+                '/api/': {
+                  get: {
+                    operationId: 'getCoreAPIVersions'
+                  }
+                }
+              }
+            })
         })
 
         it('returns an error message with the status code', (done) => {
@@ -123,7 +135,6 @@ describe('lib.swagger-client', () => {
             })
             .catch(err => {
               expect(err.message).to.equal('Failed to get /openapi/v2: 500')
-
               done()
             })
         })


### PR DESCRIPTION
Previously, only a 404 on /openapi/v2 would cause a fallback
to the /swagger.json endpoint. Now, ALL error codes from /openapi/v2
cause a fallback to swagger.json

fixes #363 