### PR TITLE
fix(request): handle 200 responses with an empty body

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -126,7 +126,7 @@ class Request {
     return request(options, (err, res, body) => {
       if (err) return cb(err)
 
-      if (isUpgradeRequired(body)) {
+      if (body && isUpgradeRequired(body)) {
         return upgradeRequest(options, cb)
       }
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,0 +1,29 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const nock = require('nock')
+
+const common = require('./common')
+const Request = require('../lib/request')
+
+const url = common.api.url
+
+describe('lib.request', () => {
+  describe('Request', () => {
+    it('handles empty responses', done => {
+      nock(url)
+        .get('/foo')
+        .reply(200)
+
+      const backend = new Request({ url })
+      backend.http({
+        method: 'GET',
+        pathname: '/foo'
+      }).then(res => {
+        expect(res.body).to.be.an('undefined')
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/godaddy/kubernetes-client/issues/376