### PR TITLE
fix(aliasing): don't alias apis (to api)

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -45,6 +45,10 @@ const esPlurals = {
   ingresses: true
 }
 
+const excludeFromAliasing = {
+  apis: true
+}
+
 module.exports = function (resourceType) {
   let aliases = [resourceType]
   if (resourceAliases[resourceType]) {
@@ -55,7 +59,9 @@ module.exports = function (resourceType) {
   // NOTE(sbw): try to catch things that shouldn't have singular aliases. This
   // fails on some relatively common resources, like "status".
   //
-  if (resourceType.slice(-1) !== 's') return aliases
+  if ((resourceType.slice(-1) !== 's') || (resourceType in excludeFromAliasing)) {
+    return aliases
+  }
 
   const trimLength = esPlurals[resourceType] ? 2 : 1
   const single = resourceType.substr(0, resourceType.length - trimLength)


### PR DESCRIPTION
/api is an endpoint, so we shouldn't alias /apis to /api.

Fixes https://github.com/godaddy/kubernetes-client/issues/391