### PR TITLE
Adding token based authorization

### DIFF
--- a/lib/backends/request.js
+++ b/lib/backends/request.js
@@ -177,6 +177,10 @@ class Request {
 
     if (options.noAuth) {
       delete requestOptions.auth
+    } else if (this.requestOptions.auth && this.requestOptions.auth.token) {
+      requestOptions.headers = requestOptions.headers || {}
+      requestOptions.headers.Authorization = `Bearer ${this.requestOptions.auth.token}`
+      delete requestOptions.auth
     }
 
     if (options.stream) return request(requestOptions)


### PR DESCRIPTION
If a developer wants to use a token associated with a service account as an authentication mechanism for kubernetes APIs then pass token as:

```js
const Client = require('kubernetes-client').Client
const client = new Client({
  config: {
    url: 'CLUSTER_URL',
    auth: {
      token: 'SERVICE ACCOUNT JWT'
    },
    insecureSkipTlsVerify: true,
  }
})
```