### PR TITLE
swagger-client: Remove noAuth

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -33,7 +33,7 @@ const Request = require('./backends/request')
 
 class Root extends Component {
   _getSpec (pathname) {
-    return this.backend.http({ method: 'GET', pathname, noAuth: true })
+    return this.backend.http({ method: 'GET', pathname })
       .then(res => {
         return res.body
       })


### PR DESCRIPTION
The /openapi/v2 endpoint is protected by authentication. Also reported by one of my downstream user on https://github.com/wongnai/kube-slack/issues/50

I'm not sure why this call was flagged with noAuth?