### PR TITLE
Fixes 404 on upgrading request

### DIFF
--- a/lib/backends/request.js
+++ b/lib/backends/request.js
@@ -56,7 +56,7 @@ function isUpgradeRequired (body) {
 
 function upgradeRequest (options, cb) {
   const queryParams = qs.stringify(options.qs, { indices: false })
-  const wsUrl = `${options.baseUrl}/${options.uri}?${queryParams}`
+  const wsUrl = `${options.baseUrl}${options.uri}?${queryParams}`
   const protocol = 'base64.channel.k8s.io'
   const ws = new WebSocket(wsUrl, protocol, options)
 


### PR DESCRIPTION
```
api_1            | Error: Unexpected server response: 404
api_1            |     at ClientRequest.<anonymous> (/opt/node_modules/ws/lib/websocket.js:558:5)
api_1            |     at ClientRequest.emit (events.js:188:13)
api_1            |     at ClientRequest.emit (domain.js:457:23)
api_1            |     at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:562:21)
api_1            |     at HTTPParser.parserOnHeadersComplete (_http_common.js:113:17)
api_1            |     at TLSSocket.socketOnData (_http_client.js:449:20)
api_1            |     at TLSSocket.emit (events.js:188:13)
api_1            |     at TLSSocket.emit (domain.js:457:23)
api_1            |     at addChunk (_stream_readable.js:288:12)
api_1            |     at readableAddChunk (_stream_readable.js:269:11)
api_1            |     at TLSSocket.push (_stream_readable.js:224:10)
api_1            |     at TLSWrap.onStreamRead (internal/stream_base_commons.js:145:17)
```