### PR TITLE
feat: ability for a user to define aliases

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const merge = require('deepmerge')
+
 // We support the full names and all the abbbreviated aliases:
 //   http://kubernetes.io/docs/user-guide/kubectl-overview/
 // and anything else we think is useful.
@@ -50,22 +52,26 @@ const excludeFromAliasing = {
   status: true
 }
 
-module.exports = function (resourceType) {
-  let aliases = [resourceType]
-  if (resourceAliases[resourceType]) {
-    aliases = aliases.concat(resourceAliases[resourceType])
-  }
+module.exports = function getNames (userAliases = {}) {
+  // Merge any user defined aliases with the current list of aliases
+  const mergedAliases = merge(resourceAliases, userAliases)
+  return function (resourceType) {
+    let aliases = [resourceType]
+    if (mergedAliases[resourceType]) {
+      aliases = aliases.concat(mergedAliases[resourceType])
+    }
 
-  //
-  // NOTE(sbw): try to catch things that shouldn't have singular aliases. This
-  // fails on some relatively common resources, like "status".
-  //
-  if ((resourceType.slice(-1) !== 's') || (resourceType in excludeFromAliasing)) {
+    //
+    // NOTE(sbw): try to catch things that shouldn't have singular aliases. This
+    // fails on some relatively common resources, like "status".
+    //
+    if ((resourceType.slice(-1) !== 's') || (resourceType in excludeFromAliasing)) {
+      return aliases
+    }
+
+    const trimLength = esPlurals[resourceType] ? 2 : 1
+    const single = resourceType.substr(0, resourceType.length - trimLength)
+    aliases.push(single)
     return aliases
   }
-
-  const trimLength = esPlurals[resourceType] ? 2 : 1
-  const single = resourceType.substr(0, resourceType.length - trimLength)
-  aliases.push(single)
-  return aliases
 }

--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -28,7 +28,7 @@ const fs = require('fs')
 const path = require('path')
 const zlib = require('zlib')
 
-const getAliases = require('./alias')
+const alias = require('./alias')
 const Request = require('./backends/request')
 
 class Root extends Component {
@@ -138,6 +138,8 @@ class Client {
         `swagger-${options.version}.json.gz`)
       spec = JSON.parse(zlib.gunzipSync(fs.readFileSync(swaggerPath)))
     }
+
+    const getAliases = alias(options.aliases)
 
     const root = new Root({ splits: [], backend, getNames: getAliases })
     if (spec) root._addSpec(spec)


### PR DESCRIPTION
This allows a user to specify their own aliases when creating a Client

The motivation for this comes from the [openshift node client ](https://github.com/nodeshift/openshift-rest-client)that my team has.  We are refactoring it to have it generate the client automatically by passing in the swagger spec.  https://github.com/nodeshift/openshift-rest-client/pull/113

There are some endpoints that openshift has, that if aliased, would be easier to work with

For example,  there is an endpoint `build.openshift.io`, which when generated into an api would be some like this: `client.api['build.openshift.io'].v1.get()`

If `build.openshift.io` was aliased to just be `build` then it would make the client api easier to use for the user, since it could then just be `client.api.build.v1.get()`

I need to add something to the readme to show how to do this, but wanted to get some thoughts on this first.



