### PR TITLE
feat: have the ability to make the request json option false

### DIFF
--- a/lib/backends/request.js
+++ b/lib/backends/request.js
@@ -171,7 +171,7 @@ class Request {
       method: options.method,
       uri,
       body: options.body,
-      json: true,
+      json: 'json' in options ? Boolean(options.json) : true,
       qs: options.parameters || options.qs,
       headers: options.headers
     }, this.requestOptions)


### PR DESCRIPTION
One of the endpoints we have in openshift, "initiatebinary", allows someone to upload a tar archive to openshift as part of there build.  In order to make it work with request, you have to specify the json option to be false.

Currently the default options in the `http` method have the json value set to true with no way to change it.  

This PR adds the ability to change that value to false if needed.  
