### PR TITLE
Updated js-yaml to 3.13.0 to patch npm vulnerability in advisory 788

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3406,9 +3406,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4051,6 +4051,16 @@
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "locate-path": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "deepmerge": "^3.0.0",
-    "js-yaml": "^3.10.0",
+    "js-yaml": "^3.13.0",
     "openid-client": "^2.4.4",
     "qs": "^6.5.2",
     "request": "^2.88.0",


### PR DESCRIPTION
npm has reported denial of service vulnerability that's affecting versions of `js-yaml` before 3.13.0.  This caused `npm audit` to fail on our modules that rely on `kubernetes-client`. 

There is an explanation of the vulnerability on this advisory: https://www.npmjs.com/advisories/788
This PR bumps the version of `js-yaml` as per the advisory's recommendation.
