### PR TITLE
feat: expose the current namespace on the config object

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -171,6 +171,7 @@ function fromKubeconfig (kubeconfig, current) {
 
   return {
     url: cluster.server,
+    namespace: context.namespace,
     auth: Object.keys(auth).length ? auth : null,
     ca: ca,
     insecureSkipTlsVerify: insecureSkipTlsVerify,


### PR DESCRIPTION
This adds the current namespace to the return value of the `fromKubeconfig` function.   I noticed this value is also returned in the `getInCluster` function.

In our openshift node client([nodeshift](https://github.com/nodeshift/nodeshift)), we us the current namespace(project in openshift terms) the user is logged into.  I can derive it from calling `loadKubeconfig` and then parsing the current context from the loaded config, but that makes an extra call to look up the configuration.

It is more of a convenience thing and i would hate to clutter the returned object, so wanted to see your thoughts

Thanks


