### PR TITLE
fix(CRDs): malformed watch paths for namespaced CRDs

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -93,8 +93,8 @@ class Root extends Component {
 
     const watchPaths = {
       watchCluster: `/apis/${group}/${version}/watch/${name}`,
-      watchNamespace: `/apis/${group}/${version}${namespace}/watch/${name}`,
-      watchResource: `/apis/${group}/${version}${namespace}/watch/${name}/{name}`
+      watchNamespace: `/apis/${group}/${version}/watch${namespace}/${name}`,
+      watchResource: `/apis/${group}/${version}/watch${namespace}/${name}/{name}`
     }
     Object.keys(watchPaths).forEach(operationId => {
       const watchPath = watchPaths[operationId]

--- a/lib/swagger-client.test.js
+++ b/lib/swagger-client.test.js
@@ -184,8 +184,8 @@ describe('lib.swagger-client', () => {
         expect(client.apis['stable.example.com'].v1.namespaces('default').foos('blah').patch).is.a('function')
         expect(client.apis['stable.example.com'].v1.namespaces('default').foos('blah').put).is.a('function')
         expect(client.apis['stable.example.com'].v1.watch.foos.getStream).is.a('function')
-        expect(client.apis['stable.example.com'].v1.namespaces('default').watch.foos.getStream).is.a('function')
-        expect(client.apis['stable.example.com'].v1.namespaces('default').watch.foos('blah').getStream).is.a('function')
+        expect(client.apis['stable.example.com'].v1.watch.namespaces('default').foos.getStream).is.a('function')
+        expect(client.apis['stable.example.com'].v1.watch.namespaces('default').foos('blah').getStream).is.a('function')
       })
 
       it('adds functions for Cluster CustomResourceDefinitions', () => {


### PR DESCRIPTION
Currently, URLs for namespaced watches for CRD
objects are incorrectly formatted (the result instead
tries to do a GET on a CRD named `watch`), causing k8s to
return a 404.
This patch corrects this issue

Fixes #468