### PR TITLE
Update auth-provider path

### DIFF
--- a/backends/request/client.js
+++ b/backends/request/client.js
@@ -13,7 +13,7 @@ const WebSocket = require('ws')
  */
 function refreshAuth (type, config) {
   return new Promise((resolve, reject) => {
-    const provider = require(`../auth-providers/${type}.js`)
+    const provider = require(`../../lib/auth-providers/${type}.js`)
     provider.refresh(config)
       .then(result => {
         const auth = {


### PR DESCRIPTION
Looks like after moving the backends, this path needs to be updated to be able to perform the relative import

using the code:
```
const Client = require('kubernetes-client').Client;
const Request = require('kubernetes-client/backends/request');
const backend = new Request(Request.config.fromKubeconfig());
const client = new Client({ backend, version: '1.13' });
await client.loadSpec();
```

i get this error
```
Error: Failed to get /openapi/v2 and /swagger.json: Cannot find module '../auth-providers/cmd.js'
Require stack:
- /Users/rsim/zendesk/scooter-ui/node_modules/kubernetes-client/backends/request/client.js
- /Users/rsim/zendesk/scooter-ui/node_modules/kubernetes-client/backends/request/index.js
- /Users/rsim/zendesk/scooter-ui/node_modules/kubernetes-client/lib/swagger-client.js
- /Users/rsim/zendesk/scooter-ui/node_modules/kubernetes-client/lib/index.js
- <repl>
    at /Users/rsim/zendesk/scooter-ui/node_modules/kubernetes-client/lib/swagger-client.js:57:15
    at processTicksAndRejections (internal/process/task_queues.js:89:5)
    at async <anonymous>:1:26
> }
```