### PR TITLE
Add quick fix for 403 throws on pod-exec

### DIFF
--- a/backends/request/client.js
+++ b/backends/request/client.js
@@ -63,6 +63,12 @@ function upgradeRequest (options, cb) {
   const queryParams = qs.stringify(options.qs, { indices: false })
   const wsUrl = urljoin(options.baseUrl, options.uri, `?${queryParams}`)
   const protocol = 'base64.channel.k8s.io'
+
+  // Passing authorization header
+  options.headers = {
+    ...options.headers,
+    authorization: `Bearer ${options.auth.bearer}`
+  }
   const ws = new WebSocket(wsUrl, protocol, options)
 
   const messages = []


### PR DESCRIPTION
## Purpose 
Exec request throws 403 error.
Exec failing route : `api.v1.namespaces(NAMESPACE).pods(PODNAME).exec.post()`.

## Problem identification
`ws` seems to only supports authorization header for token authentication which is not passed to `ws` instance. Please see this [answer](https://github.com/godaddy/kubernetes-client/issues/346#issuecomment-489602443) for more details.

The [issue](https://github.com/godaddy/kubernetes-client/issues/346#issuecomment-489602443).

I hope it helps :)