### PR TITLE
Require node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ language: node_js
 matrix:
   fast_finish: true
   include:
-    - node_js: "10"
-    - node_js: "8"
+    - node_js: "12"
 # https://github.com/greenkeeperio/greenkeeper-lockfile#npm
 before_install:
-# package-lock.json was introduced in npm@5
-- '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
 - npm install -g greenkeeper-lockfile
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload

--- a/package-lock.json
+++ b/package-lock.json
@@ -256,13 +256,10 @@
         }
       }
     },
-    "@panva/jose": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@panva/jose/-/jose-1.9.3.tgz",
-      "integrity": "sha512-oKzjM5YsCSaL+/7NDQhfqeu0xj7owqRduNLM/W+dtIyGI7/AIaPue/bz4fqjYVDTpmRtrlsserR6kiqJucmbjA==",
-      "requires": {
-        "jose": "^1.15.0"
-      }
+    "@panva/asn1.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
+      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -324,6 +321,16 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/got": {
+      "version": "9.6.9",
+      "resolved": "https://registry.npmjs.org/@types/got/-/got-9.6.9.tgz",
+      "integrity": "sha512-w+ZE+Ovp6fM+1sHwJB7RN3f3pTJHZkyABuULqbtknqezQyWadFEp5BzOXaZzRqAw2md6/d3ybxQJt+BNgpvzOg==",
+      "requires": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
     "@types/js-yaml": {
       "version": "3.12.2",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.2.tgz",
@@ -332,8 +339,7 @@
     "@types/node": {
       "version": "12.12.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-      "integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
-      "dev": true
+      "integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w=="
     },
     "@types/request": {
       "version": "2.48.4",
@@ -528,17 +534,6 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "asn1.js": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
-      "integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
-      "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -599,11 +594,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
-    },
-    "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2862,9 +2852,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -3285,11 +3275,11 @@
       }
     },
     "jose": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-1.21.1.tgz",
-      "integrity": "sha512-+PYDNfE/AgtaGNYbpmsCaGap7TD12PAh6AGekFEh2xlHYdNPNWb6YUjcGcK+NNEUflrr2fGEBsbV9aAHrZGLew==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-1.24.0.tgz",
+      "integrity": "sha512-9C9rrig50Q485d2nk8BRV9O+H5wAzFfNSRYSIyN4+epYawQg1ChZaTLAaxnNnwI8zkGjY35Q48eGRu+ar3uO1Q==",
       "requires": {
-        "asn1.js": "^5.3.0"
+        "@panva/asn1.js": "^1.0.0"
       }
     },
     "js-tokens": {
@@ -3587,9 +3577,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "map-obj": {
       "version": "2.0.0",
@@ -3771,11 +3761,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -4136,9 +4121,9 @@
       "dev": true
     },
     "object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.3.tgz",
+      "integrity": "sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg=="
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -4211,9 +4196,9 @@
       }
     },
     "oidc-token-hash": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-3.0.2.tgz",
-      "integrity": "sha512-dTzp80/y/da+um+i+sOucNqiPpwRL7M/xPwj7pH1TFA2/bqQ+OK2sJahSXbemEoLtPkHcFLyhLhLWZa9yW5+RA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.0.tgz",
+      "integrity": "sha512-8Yr4CZSv+Tn8ZkN3iN2i2w2G92mUKClp4z7EGUfdsERiYSbj7P4i/NHm72ft+aUdsiFx9UdIPSTwbyzQ6C4URg=="
     },
     "once": {
       "version": "1.4.0",
@@ -4233,18 +4218,19 @@
       }
     },
     "openid-client": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.3.0.tgz",
-      "integrity": "sha512-6E4aaD0qk9rfnuwlaqYpKpEm8X7enOjs2A1yu/kxtfZLU/zVjmRceUGjlEJXidTSb9o46dv1wTDdxqmECaOkRQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.13.0.tgz",
+      "integrity": "sha512-IhkIYjnmlnwX0tZc1r6MINXdYyyK0XLHLU31GecKXS6u2MPauStwakL2Vi0sjyLqAnqOp49BZ6VZmAdJmvb2cA==",
       "requires": {
-        "@panva/jose": "^1.3.0",
+        "@types/got": "^9.6.9",
         "base64url": "^3.0.1",
         "got": "^9.6.0",
-        "lodash": "^4.17.13",
+        "jose": "^1.23.0",
+        "lodash": "^4.17.15",
         "lru-cache": "^5.1.1",
         "make-error": "^1.3.5",
-        "object-hash": "^1.3.1",
-        "oidc-token-hash": "^3.0.2",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.0",
         "p-any": "^2.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "GoDaddy Operating Company, LLC",
   "license": "MIT",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "backends",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "depd": "^2.0.0",
     "js-yaml": "^3.13.1",
     "json-stream": "^1.0.0",
-    "openid-client": "3.3.0",
+    "openid-client": "^3.13.0",
     "pump": "^3.0.0",
     "qs": "^6.9.0",
     "request": "^2.88.0",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -34,130 +34,44 @@ export interface Configuration {
     getInCluster() : ClusterConfiguration;
 }
 
-export interface ApisAppsV1beta1WatchNamespacesNameDeploymentsName {
+export interface ApiV1NamespacesNamePodsNameProxyName {
            // Path templating
            // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           post(options ?: any): any
+           put(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1WatchNamespacesNameDeployments {
+export interface ApiV1NamespacesNamePodsNameProxy {
            // Path templating
-           (name: string): ApisAppsV1beta1WatchNamespacesNameDeploymentsName
+           (name: string): ApiV1NamespacesNamePodsNameProxyName
            // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           post(options ?: any): any
+           put(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1WatchNamespacesNameControllerrevisionsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1WatchNamespacesNameControllerrevisions {
-           // Path templating
-           (name: string): ApisAppsV1beta1WatchNamespacesNameControllerrevisionsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1WatchNamespacesNameStatefulsetsName {
+export interface ApiV1NamespacesNamePodsNameAttach {
            // Path templating
            // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
+           post(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1WatchNamespacesNameStatefulsets {
-           // Path templating
-           (name: string): ApisAppsV1beta1WatchNamespacesNameStatefulsetsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1WatchNamespacesName {
-           // Path templating
-           // Sub-paths
-           'deployments': ApisAppsV1beta1WatchNamespacesNameDeployments
-           'deploy': ApisAppsV1beta1WatchNamespacesNameDeployments
-           'deployment': ApisAppsV1beta1WatchNamespacesNameDeployments
-           'controllerrevisions': ApisAppsV1beta1WatchNamespacesNameControllerrevisions
-           'controllerrevision': ApisAppsV1beta1WatchNamespacesNameControllerrevisions
-           'statefulsets': ApisAppsV1beta1WatchNamespacesNameStatefulsets
-           'statefulset': ApisAppsV1beta1WatchNamespacesNameStatefulsets
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1WatchNamespaces {
-           // Path templating
-           (name: string): ApisAppsV1beta1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1WatchStatefulsets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1WatchDeployments {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1WatchControllerrevisions {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1Watch {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisAppsV1beta1WatchNamespaces
-           'ns': ApisAppsV1beta1WatchNamespaces
-           'namespace': ApisAppsV1beta1WatchNamespaces
-           'statefulsets': ApisAppsV1beta1WatchStatefulsets
-           'statefulset': ApisAppsV1beta1WatchStatefulsets
-           'deployments': ApisAppsV1beta1WatchDeployments
-           'deploy': ApisAppsV1beta1WatchDeployments
-           'deployment': ApisAppsV1beta1WatchDeployments
-           'controllerrevisions': ApisAppsV1beta1WatchControllerrevisions
-           'controllerrevision': ApisAppsV1beta1WatchControllerrevisions
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1NamespacesNameDeploymentsNameRollback {
+export interface ApiV1NamespacesNamePodsNameBinding {
            // Path templating
            // Sub-paths
            // Calls
@@ -165,7 +79,44 @@ export interface ApisAppsV1beta1NamespacesNameDeploymentsNameRollback {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1NamespacesNameDeploymentsNameScale {
+export interface ApiV1NamespacesNamePodsNameEviction {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNamePodsNameExec {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNamePodsNameLog {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNamePodsNamePortforward {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNamePodsNameStatus {
            // Path templating
            // Sub-paths
            // Calls
@@ -176,23 +127,17 @@ export interface ApisAppsV1beta1NamespacesNameDeploymentsNameScale {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1NamespacesNameDeploymentsNameStatus {
+export interface ApiV1NamespacesNamePodsName {
            // Path templating
            // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1NamespacesNameDeploymentsName {
-           // Path templating
-           // Sub-paths
-           'rollback': ApisAppsV1beta1NamespacesNameDeploymentsNameRollback
-           'scale': ApisAppsV1beta1NamespacesNameDeploymentsNameScale
-           'status': ApisAppsV1beta1NamespacesNameDeploymentsNameStatus
+           'proxy': ApiV1NamespacesNamePodsNameProxy
+           'attach': ApiV1NamespacesNamePodsNameAttach
+           'binding': ApiV1NamespacesNamePodsNameBinding
+           'eviction': ApiV1NamespacesNamePodsNameEviction
+           'exec': ApiV1NamespacesNamePodsNameExec
+           'log': ApiV1NamespacesNamePodsNameLog
+           'portforward': ApiV1NamespacesNamePodsNamePortforward
+           'status': ApiV1NamespacesNamePodsNameStatus
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
@@ -202,9 +147,9 @@ export interface ApisAppsV1beta1NamespacesNameDeploymentsName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1NamespacesNameDeployments {
+export interface ApiV1NamespacesNamePods {
            // Path templating
-           (name: string): ApisAppsV1beta1NamespacesNameDeploymentsName
+           (name: string): ApiV1NamespacesNamePodsName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -214,7 +159,34 @@ export interface ApisAppsV1beta1NamespacesNameDeployments {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1NamespacesNameStatefulsetsNameScale {
+export interface ApiV1NamespacesNameServicesNameProxyName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           post(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameServicesNameProxy {
+           // Path templating
+           (name: string): ApiV1NamespacesNameServicesNameProxyName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           post(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameServicesNameStatus {
            // Path templating
            // Sub-paths
            // Calls
@@ -225,22 +197,11 @@ export interface ApisAppsV1beta1NamespacesNameStatefulsetsNameScale {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1NamespacesNameStatefulsetsNameStatus {
+export interface ApiV1NamespacesNameServicesName {
            // Path templating
            // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta1NamespacesNameStatefulsetsName {
-           // Path templating
-           // Sub-paths
-           'scale': ApisAppsV1beta1NamespacesNameStatefulsetsNameScale
-           'status': ApisAppsV1beta1NamespacesNameStatefulsetsNameStatus
+           'proxy': ApiV1NamespacesNameServicesNameProxy
+           'status': ApiV1NamespacesNameServicesNameStatus
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
@@ -250,9 +211,44 @@ export interface ApisAppsV1beta1NamespacesNameStatefulsetsName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1NamespacesNameStatefulsets {
+export interface ApiV1NamespacesNameServices {
            // Path templating
-           (name: string): ApisAppsV1beta1NamespacesNameStatefulsetsName
+           (name: string): ApiV1NamespacesNameServicesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNamePersistentvolumeclaimsNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNamePersistentvolumeclaimsName {
+           // Path templating
+           // Sub-paths
+           'status': ApiV1NamespacesNamePersistentvolumeclaimsNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNamePersistentvolumeclaims {
+           // Path templating
+           (name: string): ApiV1NamespacesNamePersistentvolumeclaimsName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -262,7 +258,91 @@ export interface ApisAppsV1beta1NamespacesNameStatefulsets {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1NamespacesNameControllerrevisionsName {
+export interface ApiV1NamespacesNameReplicationcontrollersNameScale {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameReplicationcontrollersNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameReplicationcontrollersName {
+           // Path templating
+           // Sub-paths
+           'scale': ApiV1NamespacesNameReplicationcontrollersNameScale
+           'status': ApiV1NamespacesNameReplicationcontrollersNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameReplicationcontrollers {
+           // Path templating
+           (name: string): ApiV1NamespacesNameReplicationcontrollersName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameResourcequotasNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameResourcequotasName {
+           // Path templating
+           // Sub-paths
+           'status': ApiV1NamespacesNameResourcequotasNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameResourcequotas {
+           // Path templating
+           (name: string): ApiV1NamespacesNameResourcequotasName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameConfigmapsName {
            // Path templating
            // Sub-paths
            // Calls
@@ -274,9 +354,9 @@ export interface ApisAppsV1beta1NamespacesNameControllerrevisionsName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1NamespacesNameControllerrevisions {
+export interface ApiV1NamespacesNameConfigmaps {
            // Path templating
-           (name: string): ApisAppsV1beta1NamespacesNameControllerrevisionsName
+           (name: string): ApiV1NamespacesNameConfigmapsName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -286,29 +366,238 @@ export interface ApisAppsV1beta1NamespacesNameControllerrevisions {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1NamespacesName {
+export interface ApiV1NamespacesNameEndpointsName {
            // Path templating
            // Sub-paths
-           'deployments': ApisAppsV1beta1NamespacesNameDeployments
-           'deploy': ApisAppsV1beta1NamespacesNameDeployments
-           'deployment': ApisAppsV1beta1NamespacesNameDeployments
-           'statefulsets': ApisAppsV1beta1NamespacesNameStatefulsets
-           'statefulset': ApisAppsV1beta1NamespacesNameStatefulsets
-           'controllerrevisions': ApisAppsV1beta1NamespacesNameControllerrevisions
-           'controllerrevision': ApisAppsV1beta1NamespacesNameControllerrevisions
            // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1Namespaces {
+export interface ApiV1NamespacesNameEndpoints {
            // Path templating
-           (name: string): ApisAppsV1beta1NamespacesName
+           (name: string): ApiV1NamespacesNameEndpointsName
            // Sub-paths
            // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1Statefulsets {
+export interface ApiV1NamespacesNameEventsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameEvents {
+           // Path templating
+           (name: string): ApiV1NamespacesNameEventsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameLimitrangesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameLimitranges {
+           // Path templating
+           (name: string): ApiV1NamespacesNameLimitrangesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNamePodtemplatesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNamePodtemplates {
+           // Path templating
+           (name: string): ApiV1NamespacesNamePodtemplatesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameSecretsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameSecrets {
+           // Path templating
+           (name: string): ApiV1NamespacesNameSecretsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameServiceaccountsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameServiceaccounts {
+           // Path templating
+           (name: string): ApiV1NamespacesNameServiceaccountsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameBindings {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameFinalize {
+           // Path templating
+           // Sub-paths
+           // Calls
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'pods': ApiV1NamespacesNamePods
+           'po': ApiV1NamespacesNamePods
+           'pod': ApiV1NamespacesNamePods
+           'services': ApiV1NamespacesNameServices
+           'svc': ApiV1NamespacesNameServices
+           'service': ApiV1NamespacesNameServices
+           'persistentvolumeclaims': ApiV1NamespacesNamePersistentvolumeclaims
+           'pvc': ApiV1NamespacesNamePersistentvolumeclaims
+           'persistentvolumeclaim': ApiV1NamespacesNamePersistentvolumeclaims
+           'replicationcontrollers': ApiV1NamespacesNameReplicationcontrollers
+           'rc': ApiV1NamespacesNameReplicationcontrollers
+           'replicationcontroller': ApiV1NamespacesNameReplicationcontrollers
+           'resourcequotas': ApiV1NamespacesNameResourcequotas
+           'quota': ApiV1NamespacesNameResourcequotas
+           'resourcequota': ApiV1NamespacesNameResourcequotas
+           'configmaps': ApiV1NamespacesNameConfigmaps
+           'cm': ApiV1NamespacesNameConfigmaps
+           'configmap': ApiV1NamespacesNameConfigmaps
+           'endpoints': ApiV1NamespacesNameEndpoints
+           'ep': ApiV1NamespacesNameEndpoints
+           'endpoint': ApiV1NamespacesNameEndpoints
+           'events': ApiV1NamespacesNameEvents
+           'ev': ApiV1NamespacesNameEvents
+           'event': ApiV1NamespacesNameEvents
+           'limitranges': ApiV1NamespacesNameLimitranges
+           'limits': ApiV1NamespacesNameLimitranges
+           'limitrange': ApiV1NamespacesNameLimitranges
+           'podtemplates': ApiV1NamespacesNamePodtemplates
+           'podtemplate': ApiV1NamespacesNamePodtemplates
+           'secrets': ApiV1NamespacesNameSecrets
+           'secret': ApiV1NamespacesNameSecrets
+           'serviceaccounts': ApiV1NamespacesNameServiceaccounts
+           'serviceaccount': ApiV1NamespacesNameServiceaccounts
+           'bindings': ApiV1NamespacesNameBindings
+           'binding': ApiV1NamespacesNameBindings
+           'finalize': ApiV1NamespacesNameFinalize
+           'status': ApiV1NamespacesNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Namespaces {
+           // Path templating
+           (name: string): ApiV1NamespacesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameConfigmapsName {
            // Path templating
            // Sub-paths
            // Calls
@@ -317,7 +606,17 @@ export interface ApisAppsV1beta1Statefulsets {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1Controllerrevisions {
+export interface ApiV1WatchNamespacesNameConfigmaps {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNameConfigmapsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameEndpointsName {
            // Path templating
            // Sub-paths
            // Calls
@@ -326,7 +625,17 @@ export interface ApisAppsV1beta1Controllerrevisions {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1Deployments {
+export interface ApiV1WatchNamespacesNameEndpoints {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNameEndpointsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameEventsName {
            // Path templating
            // Sub-paths
            // Calls
@@ -335,20 +644,720 @@ export interface ApisAppsV1beta1Deployments {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta1 {
+export interface ApiV1WatchNamespacesNameEvents {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNameEventsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameLimitrangesName {
            // Path templating
            // Sub-paths
-           'watch': ApisAppsV1beta1Watch
-           'namespaces': ApisAppsV1beta1Namespaces
-           'ns': ApisAppsV1beta1Namespaces
-           'namespace': ApisAppsV1beta1Namespaces
-           'statefulsets': ApisAppsV1beta1Statefulsets
-           'statefulset': ApisAppsV1beta1Statefulsets
-           'controllerrevisions': ApisAppsV1beta1Controllerrevisions
-           'controllerrevision': ApisAppsV1beta1Controllerrevisions
-           'deployments': ApisAppsV1beta1Deployments
-           'deploy': ApisAppsV1beta1Deployments
-           'deployment': ApisAppsV1beta1Deployments
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameLimitranges {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNameLimitrangesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNamePersistentvolumeclaimsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNamePersistentvolumeclaims {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNamePersistentvolumeclaimsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNamePodsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNamePods {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNamePodsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNamePodtemplatesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNamePodtemplates {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNamePodtemplatesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameReplicationcontrollersName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameReplicationcontrollers {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNameReplicationcontrollersName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameResourcequotasName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameResourcequotas {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNameResourcequotasName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameSecretsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameSecrets {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNameSecretsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameServiceaccountsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameServiceaccounts {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNameServiceaccountsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameServicesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesNameServices {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesNameServicesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespacesName {
+           // Path templating
+           // Sub-paths
+           'configmaps': ApiV1WatchNamespacesNameConfigmaps
+           'cm': ApiV1WatchNamespacesNameConfigmaps
+           'configmap': ApiV1WatchNamespacesNameConfigmaps
+           'endpoints': ApiV1WatchNamespacesNameEndpoints
+           'ep': ApiV1WatchNamespacesNameEndpoints
+           'endpoint': ApiV1WatchNamespacesNameEndpoints
+           'events': ApiV1WatchNamespacesNameEvents
+           'ev': ApiV1WatchNamespacesNameEvents
+           'event': ApiV1WatchNamespacesNameEvents
+           'limitranges': ApiV1WatchNamespacesNameLimitranges
+           'limits': ApiV1WatchNamespacesNameLimitranges
+           'limitrange': ApiV1WatchNamespacesNameLimitranges
+           'persistentvolumeclaims': ApiV1WatchNamespacesNamePersistentvolumeclaims
+           'pvc': ApiV1WatchNamespacesNamePersistentvolumeclaims
+           'persistentvolumeclaim': ApiV1WatchNamespacesNamePersistentvolumeclaims
+           'pods': ApiV1WatchNamespacesNamePods
+           'po': ApiV1WatchNamespacesNamePods
+           'pod': ApiV1WatchNamespacesNamePods
+           'podtemplates': ApiV1WatchNamespacesNamePodtemplates
+           'podtemplate': ApiV1WatchNamespacesNamePodtemplates
+           'replicationcontrollers': ApiV1WatchNamespacesNameReplicationcontrollers
+           'rc': ApiV1WatchNamespacesNameReplicationcontrollers
+           'replicationcontroller': ApiV1WatchNamespacesNameReplicationcontrollers
+           'resourcequotas': ApiV1WatchNamespacesNameResourcequotas
+           'quota': ApiV1WatchNamespacesNameResourcequotas
+           'resourcequota': ApiV1WatchNamespacesNameResourcequotas
+           'secrets': ApiV1WatchNamespacesNameSecrets
+           'secret': ApiV1WatchNamespacesNameSecrets
+           'serviceaccounts': ApiV1WatchNamespacesNameServiceaccounts
+           'serviceaccount': ApiV1WatchNamespacesNameServiceaccounts
+           'services': ApiV1WatchNamespacesNameServices
+           'svc': ApiV1WatchNamespacesNameServices
+           'service': ApiV1WatchNamespacesNameServices
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNamespaces {
+           // Path templating
+           (name: string): ApiV1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNodesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchNodes {
+           // Path templating
+           (name: string): ApiV1WatchNodesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchPersistentvolumesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchPersistentvolumes {
+           // Path templating
+           (name: string): ApiV1WatchPersistentvolumesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchConfigmaps {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchEndpoints {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchEvents {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchLimitranges {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchPersistentvolumeclaims {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchPods {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchPodtemplates {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchReplicationcontrollers {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchResourcequotas {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchSecrets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchServiceaccounts {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1WatchServices {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApiV1WatchNamespaces
+           'ns': ApiV1WatchNamespaces
+           'namespace': ApiV1WatchNamespaces
+           'nodes': ApiV1WatchNodes
+           'no': ApiV1WatchNodes
+           'node': ApiV1WatchNodes
+           'persistentvolumes': ApiV1WatchPersistentvolumes
+           'pv': ApiV1WatchPersistentvolumes
+           'persistentvolume': ApiV1WatchPersistentvolumes
+           'configmaps': ApiV1WatchConfigmaps
+           'cm': ApiV1WatchConfigmaps
+           'configmap': ApiV1WatchConfigmaps
+           'endpoints': ApiV1WatchEndpoints
+           'ep': ApiV1WatchEndpoints
+           'endpoint': ApiV1WatchEndpoints
+           'events': ApiV1WatchEvents
+           'ev': ApiV1WatchEvents
+           'event': ApiV1WatchEvents
+           'limitranges': ApiV1WatchLimitranges
+           'limits': ApiV1WatchLimitranges
+           'limitrange': ApiV1WatchLimitranges
+           'persistentvolumeclaims': ApiV1WatchPersistentvolumeclaims
+           'pvc': ApiV1WatchPersistentvolumeclaims
+           'persistentvolumeclaim': ApiV1WatchPersistentvolumeclaims
+           'pods': ApiV1WatchPods
+           'po': ApiV1WatchPods
+           'pod': ApiV1WatchPods
+           'podtemplates': ApiV1WatchPodtemplates
+           'podtemplate': ApiV1WatchPodtemplates
+           'replicationcontrollers': ApiV1WatchReplicationcontrollers
+           'rc': ApiV1WatchReplicationcontrollers
+           'replicationcontroller': ApiV1WatchReplicationcontrollers
+           'resourcequotas': ApiV1WatchResourcequotas
+           'quota': ApiV1WatchResourcequotas
+           'resourcequota': ApiV1WatchResourcequotas
+           'secrets': ApiV1WatchSecrets
+           'secret': ApiV1WatchSecrets
+           'serviceaccounts': ApiV1WatchServiceaccounts
+           'serviceaccount': ApiV1WatchServiceaccounts
+           'services': ApiV1WatchServices
+           'svc': ApiV1WatchServices
+           'service': ApiV1WatchServices
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NodesNameProxyName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           post(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NodesNameProxy {
+           // Path templating
+           (name: string): ApiV1NodesNameProxyName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           post(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NodesNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1NodesName {
+           // Path templating
+           // Sub-paths
+           'proxy': ApiV1NodesNameProxy
+           'status': ApiV1NodesNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Nodes {
+           // Path templating
+           (name: string): ApiV1NodesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1PersistentvolumesNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1PersistentvolumesName {
+           // Path templating
+           // Sub-paths
+           'status': ApiV1PersistentvolumesNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Persistentvolumes {
+           // Path templating
+           (name: string): ApiV1PersistentvolumesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1ComponentstatusesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Componentstatuses {
+           // Path templating
+           (name: string): ApiV1ComponentstatusesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Configmaps {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Endpoints {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Events {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Limitranges {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Persistentvolumeclaims {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Pods {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Podtemplates {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Replicationcontrollers {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Resourcequotas {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Secrets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Serviceaccounts {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1Services {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApiV1 {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApiV1Namespaces
+           'ns': ApiV1Namespaces
+           'namespace': ApiV1Namespaces
+           'watch': ApiV1Watch
+           'nodes': ApiV1Nodes
+           'no': ApiV1Nodes
+           'node': ApiV1Nodes
+           'persistentvolumes': ApiV1Persistentvolumes
+           'pv': ApiV1Persistentvolumes
+           'persistentvolume': ApiV1Persistentvolumes
+           'componentstatuses': ApiV1Componentstatuses
+           'cs': ApiV1Componentstatuses
+           'componentstatus': ApiV1Componentstatuses
+           'configmaps': ApiV1Configmaps
+           'cm': ApiV1Configmaps
+           'configmap': ApiV1Configmaps
+           'endpoints': ApiV1Endpoints
+           'ep': ApiV1Endpoints
+           'endpoint': ApiV1Endpoints
+           'events': ApiV1Events
+           'ev': ApiV1Events
+           'event': ApiV1Events
+           'limitranges': ApiV1Limitranges
+           'limits': ApiV1Limitranges
+           'limitrange': ApiV1Limitranges
+           'persistentvolumeclaims': ApiV1Persistentvolumeclaims
+           'pvc': ApiV1Persistentvolumeclaims
+           'persistentvolumeclaim': ApiV1Persistentvolumeclaims
+           'pods': ApiV1Pods
+           'po': ApiV1Pods
+           'pod': ApiV1Pods
+           'podtemplates': ApiV1Podtemplates
+           'podtemplate': ApiV1Podtemplates
+           'replicationcontrollers': ApiV1Replicationcontrollers
+           'rc': ApiV1Replicationcontrollers
+           'replicationcontroller': ApiV1Replicationcontrollers
+           'resourcequotas': ApiV1Resourcequotas
+           'quota': ApiV1Resourcequotas
+           'resourcequota': ApiV1Resourcequotas
+           'secrets': ApiV1Secrets
+           'secret': ApiV1Secrets
+           'serviceaccounts': ApiV1Serviceaccounts
+           'serviceaccount': ApiV1Serviceaccounts
+           'services': ApiV1Services
+           'svc': ApiV1Services
+           'service': ApiV1Services
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface Api {
+           // Path templating
+           // Sub-paths
+           'v1': ApiV1
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
@@ -710,25 +1719,7 @@ export interface ApisAppsV1WatchNamespaces {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1WatchStatefulsets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1WatchReplicasets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1WatchDeployments {
+export interface ApisAppsV1WatchControllerrevisions {
            // Path templating
            // Sub-paths
            // Calls
@@ -746,7 +1737,25 @@ export interface ApisAppsV1WatchDaemonsets {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1WatchControllerrevisions {
+export interface ApisAppsV1WatchDeployments {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1WatchReplicasets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1WatchStatefulsets {
            // Path templating
            // Sub-paths
            // Calls
@@ -761,38 +1770,20 @@ export interface ApisAppsV1Watch {
            'namespaces': ApisAppsV1WatchNamespaces
            'ns': ApisAppsV1WatchNamespaces
            'namespace': ApisAppsV1WatchNamespaces
-           'statefulsets': ApisAppsV1WatchStatefulsets
-           'statefulset': ApisAppsV1WatchStatefulsets
-           'replicasets': ApisAppsV1WatchReplicasets
-           'rs': ApisAppsV1WatchReplicasets
-           'replicaset': ApisAppsV1WatchReplicasets
-           'deployments': ApisAppsV1WatchDeployments
-           'deploy': ApisAppsV1WatchDeployments
-           'deployment': ApisAppsV1WatchDeployments
+           'controllerrevisions': ApisAppsV1WatchControllerrevisions
+           'controllerrevision': ApisAppsV1WatchControllerrevisions
            'daemonsets': ApisAppsV1WatchDaemonsets
            'ds': ApisAppsV1WatchDaemonsets
            'daemonset': ApisAppsV1WatchDaemonsets
-           'controllerrevisions': ApisAppsV1WatchControllerrevisions
-           'controllerrevision': ApisAppsV1WatchControllerrevisions
+           'deployments': ApisAppsV1WatchDeployments
+           'deploy': ApisAppsV1WatchDeployments
+           'deployment': ApisAppsV1WatchDeployments
+           'replicasets': ApisAppsV1WatchReplicasets
+           'rs': ApisAppsV1WatchReplicasets
+           'replicaset': ApisAppsV1WatchReplicasets
+           'statefulsets': ApisAppsV1WatchStatefulsets
+           'statefulset': ApisAppsV1WatchStatefulsets
            // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1Replicasets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1Statefulsets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
@@ -823,6 +1814,24 @@ export interface ApisAppsV1Deployments {
            addCustomResourceDefinition(schema: object): void
        }
 
+export interface ApisAppsV1Replicasets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1Statefulsets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
 export interface ApisAppsV1 {
            // Path templating
            // Sub-paths
@@ -830,11 +1839,6 @@ export interface ApisAppsV1 {
            'ns': ApisAppsV1Namespaces
            'namespace': ApisAppsV1Namespaces
            'watch': ApisAppsV1Watch
-           'replicasets': ApisAppsV1Replicasets
-           'rs': ApisAppsV1Replicasets
-           'replicaset': ApisAppsV1Replicasets
-           'statefulsets': ApisAppsV1Statefulsets
-           'statefulset': ApisAppsV1Statefulsets
            'controllerrevisions': ApisAppsV1Controllerrevisions
            'controllerrevision': ApisAppsV1Controllerrevisions
            'daemonsets': ApisAppsV1Daemonsets
@@ -843,6 +1847,332 @@ export interface ApisAppsV1 {
            'deployments': ApisAppsV1Deployments
            'deploy': ApisAppsV1Deployments
            'deployment': ApisAppsV1Deployments
+           'replicasets': ApisAppsV1Replicasets
+           'rs': ApisAppsV1Replicasets
+           'replicaset': ApisAppsV1Replicasets
+           'statefulsets': ApisAppsV1Statefulsets
+           'statefulset': ApisAppsV1Statefulsets
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameDeploymentsNameRollback {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameDeploymentsNameScale {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameDeploymentsNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameDeploymentsName {
+           // Path templating
+           // Sub-paths
+           'rollback': ApisAppsV1beta1NamespacesNameDeploymentsNameRollback
+           'scale': ApisAppsV1beta1NamespacesNameDeploymentsNameScale
+           'status': ApisAppsV1beta1NamespacesNameDeploymentsNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameDeployments {
+           // Path templating
+           (name: string): ApisAppsV1beta1NamespacesNameDeploymentsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameStatefulsetsNameScale {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameStatefulsetsNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameStatefulsetsName {
+           // Path templating
+           // Sub-paths
+           'scale': ApisAppsV1beta1NamespacesNameStatefulsetsNameScale
+           'status': ApisAppsV1beta1NamespacesNameStatefulsetsNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameStatefulsets {
+           // Path templating
+           (name: string): ApisAppsV1beta1NamespacesNameStatefulsetsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameControllerrevisionsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesNameControllerrevisions {
+           // Path templating
+           (name: string): ApisAppsV1beta1NamespacesNameControllerrevisionsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'deployments': ApisAppsV1beta1NamespacesNameDeployments
+           'deploy': ApisAppsV1beta1NamespacesNameDeployments
+           'deployment': ApisAppsV1beta1NamespacesNameDeployments
+           'statefulsets': ApisAppsV1beta1NamespacesNameStatefulsets
+           'statefulset': ApisAppsV1beta1NamespacesNameStatefulsets
+           'controllerrevisions': ApisAppsV1beta1NamespacesNameControllerrevisions
+           'controllerrevision': ApisAppsV1beta1NamespacesNameControllerrevisions
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1Namespaces {
+           // Path templating
+           (name: string): ApisAppsV1beta1NamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchNamespacesNameControllerrevisionsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchNamespacesNameControllerrevisions {
+           // Path templating
+           (name: string): ApisAppsV1beta1WatchNamespacesNameControllerrevisionsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchNamespacesNameDeploymentsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchNamespacesNameDeployments {
+           // Path templating
+           (name: string): ApisAppsV1beta1WatchNamespacesNameDeploymentsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchNamespacesNameStatefulsetsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchNamespacesNameStatefulsets {
+           // Path templating
+           (name: string): ApisAppsV1beta1WatchNamespacesNameStatefulsetsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchNamespacesName {
+           // Path templating
+           // Sub-paths
+           'controllerrevisions': ApisAppsV1beta1WatchNamespacesNameControllerrevisions
+           'controllerrevision': ApisAppsV1beta1WatchNamespacesNameControllerrevisions
+           'deployments': ApisAppsV1beta1WatchNamespacesNameDeployments
+           'deploy': ApisAppsV1beta1WatchNamespacesNameDeployments
+           'deployment': ApisAppsV1beta1WatchNamespacesNameDeployments
+           'statefulsets': ApisAppsV1beta1WatchNamespacesNameStatefulsets
+           'statefulset': ApisAppsV1beta1WatchNamespacesNameStatefulsets
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchNamespaces {
+           // Path templating
+           (name: string): ApisAppsV1beta1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchControllerrevisions {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchDeployments {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1WatchStatefulsets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisAppsV1beta1WatchNamespaces
+           'ns': ApisAppsV1beta1WatchNamespaces
+           'namespace': ApisAppsV1beta1WatchNamespaces
+           'controllerrevisions': ApisAppsV1beta1WatchControllerrevisions
+           'controllerrevision': ApisAppsV1beta1WatchControllerrevisions
+           'deployments': ApisAppsV1beta1WatchDeployments
+           'deploy': ApisAppsV1beta1WatchDeployments
+           'deployment': ApisAppsV1beta1WatchDeployments
+           'statefulsets': ApisAppsV1beta1WatchStatefulsets
+           'statefulset': ApisAppsV1beta1WatchStatefulsets
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1Controllerrevisions {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1Deployments {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1Statefulsets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta1 {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisAppsV1beta1Namespaces
+           'ns': ApisAppsV1beta1Namespaces
+           'namespace': ApisAppsV1beta1Namespaces
+           'watch': ApisAppsV1beta1Watch
+           'controllerrevisions': ApisAppsV1beta1Controllerrevisions
+           'controllerrevision': ApisAppsV1beta1Controllerrevisions
+           'deployments': ApisAppsV1beta1Deployments
+           'deploy': ApisAppsV1beta1Deployments
+           'deployment': ApisAppsV1beta1Deployments
+           'statefulsets': ApisAppsV1beta1Statefulsets
+           'statefulset': ApisAppsV1beta1Statefulsets
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
@@ -1204,25 +2534,7 @@ export interface ApisAppsV1beta2WatchNamespaces {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta2WatchStatefulsets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta2WatchReplicasets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAppsV1beta2WatchDeployments {
+export interface ApisAppsV1beta2WatchControllerrevisions {
            // Path templating
            // Sub-paths
            // Calls
@@ -1240,7 +2552,25 @@ export interface ApisAppsV1beta2WatchDaemonsets {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAppsV1beta2WatchControllerrevisions {
+export interface ApisAppsV1beta2WatchDeployments {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta2WatchReplicasets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAppsV1beta2WatchStatefulsets {
            // Path templating
            // Sub-paths
            // Calls
@@ -1255,19 +2585,19 @@ export interface ApisAppsV1beta2Watch {
            'namespaces': ApisAppsV1beta2WatchNamespaces
            'ns': ApisAppsV1beta2WatchNamespaces
            'namespace': ApisAppsV1beta2WatchNamespaces
-           'statefulsets': ApisAppsV1beta2WatchStatefulsets
-           'statefulset': ApisAppsV1beta2WatchStatefulsets
-           'replicasets': ApisAppsV1beta2WatchReplicasets
-           'rs': ApisAppsV1beta2WatchReplicasets
-           'replicaset': ApisAppsV1beta2WatchReplicasets
-           'deployments': ApisAppsV1beta2WatchDeployments
-           'deploy': ApisAppsV1beta2WatchDeployments
-           'deployment': ApisAppsV1beta2WatchDeployments
+           'controllerrevisions': ApisAppsV1beta2WatchControllerrevisions
+           'controllerrevision': ApisAppsV1beta2WatchControllerrevisions
            'daemonsets': ApisAppsV1beta2WatchDaemonsets
            'ds': ApisAppsV1beta2WatchDaemonsets
            'daemonset': ApisAppsV1beta2WatchDaemonsets
-           'controllerrevisions': ApisAppsV1beta2WatchControllerrevisions
-           'controllerrevision': ApisAppsV1beta2WatchControllerrevisions
+           'deployments': ApisAppsV1beta2WatchDeployments
+           'deploy': ApisAppsV1beta2WatchDeployments
+           'deployment': ApisAppsV1beta2WatchDeployments
+           'replicasets': ApisAppsV1beta2WatchReplicasets
+           'rs': ApisAppsV1beta2WatchReplicasets
+           'replicaset': ApisAppsV1beta2WatchReplicasets
+           'statefulsets': ApisAppsV1beta2WatchStatefulsets
+           'statefulset': ApisAppsV1beta2WatchStatefulsets
            // Calls
            addCustomResourceDefinition(schema: object): void
        }
@@ -1346,1913 +2676,9 @@ export interface ApisAppsV1beta2 {
 export interface ApisApps {
            // Path templating
            // Sub-paths
-           'v1beta1': ApisAppsV1beta1
            'v1': ApisAppsV1
+           'v1beta1': ApisAppsV1beta1
            'v1beta2': ApisAppsV1beta2
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresetsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresets {
-           // Path templating
-           (name: string): ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresetsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1WatchNamespacesName {
-           // Path templating
-           // Sub-paths
-           'podpresets': ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresets
-           'podpreset': ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresets
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1WatchNamespaces {
-           // Path templating
-           (name: string): ApisSettings_k8s_ioV1alpha1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1WatchPodpresets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1Watch {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisSettings_k8s_ioV1alpha1WatchNamespaces
-           'ns': ApisSettings_k8s_ioV1alpha1WatchNamespaces
-           'namespace': ApisSettings_k8s_ioV1alpha1WatchNamespaces
-           'podpresets': ApisSettings_k8s_ioV1alpha1WatchPodpresets
-           'podpreset': ApisSettings_k8s_ioV1alpha1WatchPodpresets
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresetsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresets {
-           // Path templating
-           (name: string): ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresetsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'podpresets': ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresets
-           'podpreset': ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresets
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1Namespaces {
-           // Path templating
-           (name: string): ApisSettings_k8s_ioV1alpha1NamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1Podpresets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_ioV1alpha1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisSettings_k8s_ioV1alpha1Watch
-           'namespaces': ApisSettings_k8s_ioV1alpha1Namespaces
-           'ns': ApisSettings_k8s_ioV1alpha1Namespaces
-           'namespace': ApisSettings_k8s_ioV1alpha1Namespaces
-           'podpresets': ApisSettings_k8s_ioV1alpha1Podpresets
-           'podpreset': ApisSettings_k8s_ioV1alpha1Podpresets
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisSettings_k8s_io {
-           // Path templating
-           // Sub-paths
-           'v1alpha1': ApisSettings_k8s_ioV1alpha1
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRoles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesName {
-           // Path templating
-           // Sub-paths
-           'rolebindings': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindings
-           'roles': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRoles
-           'role': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRoles
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespaces {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchClusterroles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchRolebindings {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1WatchRoles {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1Watch {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespaces
-           'ns': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespaces
-           'namespace': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespaces
-           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindings
-           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindings
-           'clusterroles': ApisRbac_authorization_k8s_ioV1alpha1WatchClusterroles
-           'clusterrole': ApisRbac_authorization_k8s_ioV1alpha1WatchClusterroles
-           'rolebindings': ApisRbac_authorization_k8s_ioV1alpha1WatchRolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1alpha1WatchRolebindings
-           'roles': ApisRbac_authorization_k8s_ioV1alpha1WatchRoles
-           'role': ApisRbac_authorization_k8s_ioV1alpha1WatchRoles
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRoles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'roles': ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRoles
-           'role': ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRoles
-           'rolebindings': ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindings
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1Namespaces {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1NamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1ClusterrolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1Clusterrolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1ClusterrolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1ClusterrolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1Clusterroles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1alpha1ClusterrolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1Rolebindings {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1Roles {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1alpha1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisRbac_authorization_k8s_ioV1alpha1Watch
-           'namespaces': ApisRbac_authorization_k8s_ioV1alpha1Namespaces
-           'ns': ApisRbac_authorization_k8s_ioV1alpha1Namespaces
-           'namespace': ApisRbac_authorization_k8s_ioV1alpha1Namespaces
-           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1alpha1Clusterrolebindings
-           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1alpha1Clusterrolebindings
-           'clusterroles': ApisRbac_authorization_k8s_ioV1alpha1Clusterroles
-           'clusterrole': ApisRbac_authorization_k8s_ioV1alpha1Clusterroles
-           'rolebindings': ApisRbac_authorization_k8s_ioV1alpha1Rolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1alpha1Rolebindings
-           'roles': ApisRbac_authorization_k8s_ioV1alpha1Roles
-           'role': ApisRbac_authorization_k8s_ioV1alpha1Roles
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRoles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesName {
-           // Path templating
-           // Sub-paths
-           'roles': ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRoles
-           'role': ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRoles
-           'rolebindings': ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindings
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchNamespaces {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchClusterrolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchClusterroles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1WatchClusterrolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchClusterrolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchClusterrolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1WatchClusterrolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchRolebindings {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1WatchRoles {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1Watch {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisRbac_authorization_k8s_ioV1WatchNamespaces
-           'ns': ApisRbac_authorization_k8s_ioV1WatchNamespaces
-           'namespace': ApisRbac_authorization_k8s_ioV1WatchNamespaces
-           'clusterroles': ApisRbac_authorization_k8s_ioV1WatchClusterroles
-           'clusterrole': ApisRbac_authorization_k8s_ioV1WatchClusterroles
-           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1WatchClusterrolebindings
-           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1WatchClusterrolebindings
-           'rolebindings': ApisRbac_authorization_k8s_ioV1WatchRolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1WatchRolebindings
-           'roles': ApisRbac_authorization_k8s_ioV1WatchRoles
-           'role': ApisRbac_authorization_k8s_ioV1WatchRoles
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1NamespacesNameRolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1NamespacesNameRoles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1NamespacesNameRolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'roles': ApisRbac_authorization_k8s_ioV1NamespacesNameRoles
-           'role': ApisRbac_authorization_k8s_ioV1NamespacesNameRoles
-           'rolebindings': ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindings
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1Namespaces {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1NamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1ClusterrolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1Clusterrolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1ClusterrolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1ClusterrolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1Clusterroles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1ClusterrolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1Rolebindings {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1Roles {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisRbac_authorization_k8s_ioV1Watch
-           'namespaces': ApisRbac_authorization_k8s_ioV1Namespaces
-           'ns': ApisRbac_authorization_k8s_ioV1Namespaces
-           'namespace': ApisRbac_authorization_k8s_ioV1Namespaces
-           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1Clusterrolebindings
-           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1Clusterrolebindings
-           'clusterroles': ApisRbac_authorization_k8s_ioV1Clusterroles
-           'clusterrole': ApisRbac_authorization_k8s_ioV1Clusterroles
-           'rolebindings': ApisRbac_authorization_k8s_ioV1Rolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1Rolebindings
-           'roles': ApisRbac_authorization_k8s_ioV1Roles
-           'role': ApisRbac_authorization_k8s_ioV1Roles
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRoles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesName {
-           // Path templating
-           // Sub-paths
-           'rolebindings': ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindings
-           'roles': ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRoles
-           'role': ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRoles
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespaces {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchClusterroles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchRoles {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1WatchRolebindings {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1Watch {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisRbac_authorization_k8s_ioV1beta1WatchNamespaces
-           'ns': ApisRbac_authorization_k8s_ioV1beta1WatchNamespaces
-           'namespace': ApisRbac_authorization_k8s_ioV1beta1WatchNamespaces
-           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindings
-           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindings
-           'clusterroles': ApisRbac_authorization_k8s_ioV1beta1WatchClusterroles
-           'clusterrole': ApisRbac_authorization_k8s_ioV1beta1WatchClusterroles
-           'roles': ApisRbac_authorization_k8s_ioV1beta1WatchRoles
-           'role': ApisRbac_authorization_k8s_ioV1beta1WatchRoles
-           'rolebindings': ApisRbac_authorization_k8s_ioV1beta1WatchRolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1beta1WatchRolebindings
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRoles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'rolebindings': ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindings
-           'roles': ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRoles
-           'role': ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRoles
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1Namespaces {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1NamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1ClusterrolebindingsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1Clusterrolebindings {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1ClusterrolebindingsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1ClusterrolesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1Clusterroles {
-           // Path templating
-           (name: string): ApisRbac_authorization_k8s_ioV1beta1ClusterrolesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1Rolebindings {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1Roles {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_ioV1beta1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisRbac_authorization_k8s_ioV1beta1Watch
-           'namespaces': ApisRbac_authorization_k8s_ioV1beta1Namespaces
-           'ns': ApisRbac_authorization_k8s_ioV1beta1Namespaces
-           'namespace': ApisRbac_authorization_k8s_ioV1beta1Namespaces
-           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1beta1Clusterrolebindings
-           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1beta1Clusterrolebindings
-           'clusterroles': ApisRbac_authorization_k8s_ioV1beta1Clusterroles
-           'clusterrole': ApisRbac_authorization_k8s_ioV1beta1Clusterroles
-           'rolebindings': ApisRbac_authorization_k8s_ioV1beta1Rolebindings
-           'rolebinding': ApisRbac_authorization_k8s_ioV1beta1Rolebindings
-           'roles': ApisRbac_authorization_k8s_ioV1beta1Roles
-           'role': ApisRbac_authorization_k8s_ioV1beta1Roles
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisRbac_authorization_k8s_io {
-           // Path templating
-           // Sub-paths
-           'v1alpha1': ApisRbac_authorization_k8s_ioV1alpha1
-           'v1': ApisRbac_authorization_k8s_ioV1
-           'v1beta1': ApisRbac_authorization_k8s_ioV1beta1
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgetsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgets {
-           // Path templating
-           (name: string): ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgetsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1WatchNamespacesName {
-           // Path templating
-           // Sub-paths
-           'poddisruptionbudgets': ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgets
-           'poddisruptionbudget': ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgets
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1WatchNamespaces {
-           // Path templating
-           (name: string): ApisPolicyV1beta1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1WatchPodsecuritypoliciesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1WatchPodsecuritypolicies {
-           // Path templating
-           (name: string): ApisPolicyV1beta1WatchPodsecuritypoliciesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1WatchPoddisruptionbudgets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1Watch {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisPolicyV1beta1WatchNamespaces
-           'ns': ApisPolicyV1beta1WatchNamespaces
-           'namespace': ApisPolicyV1beta1WatchNamespaces
-           'podsecuritypolicies': ApisPolicyV1beta1WatchPodsecuritypolicies
-           'podsecuritypolicie': ApisPolicyV1beta1WatchPodsecuritypolicies
-           'poddisruptionbudgets': ApisPolicyV1beta1WatchPoddisruptionbudgets
-           'poddisruptionbudget': ApisPolicyV1beta1WatchPoddisruptionbudgets
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1NamespacesNamePoddisruptionbudgetsNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1NamespacesNamePoddisruptionbudgetsName {
-           // Path templating
-           // Sub-paths
-           'status': ApisPolicyV1beta1NamespacesNamePoddisruptionbudgetsNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1NamespacesNamePoddisruptionbudgets {
-           // Path templating
-           (name: string): ApisPolicyV1beta1NamespacesNamePoddisruptionbudgetsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'poddisruptionbudgets': ApisPolicyV1beta1NamespacesNamePoddisruptionbudgets
-           'poddisruptionbudget': ApisPolicyV1beta1NamespacesNamePoddisruptionbudgets
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1Namespaces {
-           // Path templating
-           (name: string): ApisPolicyV1beta1NamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1PodsecuritypoliciesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1Podsecuritypolicies {
-           // Path templating
-           (name: string): ApisPolicyV1beta1PodsecuritypoliciesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1Poddisruptionbudgets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicyV1beta1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisPolicyV1beta1Watch
-           'namespaces': ApisPolicyV1beta1Namespaces
-           'ns': ApisPolicyV1beta1Namespaces
-           'namespace': ApisPolicyV1beta1Namespaces
-           'podsecuritypolicies': ApisPolicyV1beta1Podsecuritypolicies
-           'podsecuritypolicie': ApisPolicyV1beta1Podsecuritypolicies
-           'poddisruptionbudgets': ApisPolicyV1beta1Poddisruptionbudgets
-           'poddisruptionbudget': ApisPolicyV1beta1Poddisruptionbudgets
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisPolicy {
-           // Path templating
-           // Sub-paths
-           'v1beta1': ApisPolicyV1beta1
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpoliciesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpolicies {
-           // Path templating
-           (name: string): ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpoliciesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1WatchNamespacesName {
-           // Path templating
-           // Sub-paths
-           'networkpolicies': ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpolicies
-           'networkpolicie': ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpolicies
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1WatchNamespaces {
-           // Path templating
-           (name: string): ApisNetworking_k8s_ioV1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1WatchNetworkpolicies {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1Watch {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisNetworking_k8s_ioV1WatchNamespaces
-           'ns': ApisNetworking_k8s_ioV1WatchNamespaces
-           'namespace': ApisNetworking_k8s_ioV1WatchNamespaces
-           'networkpolicies': ApisNetworking_k8s_ioV1WatchNetworkpolicies
-           'networkpolicie': ApisNetworking_k8s_ioV1WatchNetworkpolicies
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1NamespacesNameNetworkpoliciesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1NamespacesNameNetworkpolicies {
-           // Path templating
-           (name: string): ApisNetworking_k8s_ioV1NamespacesNameNetworkpoliciesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'networkpolicies': ApisNetworking_k8s_ioV1NamespacesNameNetworkpolicies
-           'networkpolicie': ApisNetworking_k8s_ioV1NamespacesNameNetworkpolicies
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1Namespaces {
-           // Path templating
-           (name: string): ApisNetworking_k8s_ioV1NamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1Networkpolicies {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_ioV1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisNetworking_k8s_ioV1Watch
-           'namespaces': ApisNetworking_k8s_ioV1Namespaces
-           'ns': ApisNetworking_k8s_ioV1Namespaces
-           'namespace': ApisNetworking_k8s_ioV1Namespaces
-           'networkpolicies': ApisNetworking_k8s_ioV1Networkpolicies
-           'networkpolicie': ApisNetworking_k8s_ioV1Networkpolicies
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisNetworking_k8s_io {
-           // Path templating
-           // Sub-paths
-           'v1': ApisNetworking_k8s_ioV1
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameReplicasetsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameReplicasets {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1WatchNamespacesNameReplicasetsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameNetworkpoliciesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameNetworkpolicies {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1WatchNamespacesNameNetworkpoliciesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameIngressesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameIngresses {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1WatchNamespacesNameIngressesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameDeploymentsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameDeployments {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1WatchNamespacesNameDeploymentsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameDaemonsetsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesNameDaemonsets {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1WatchNamespacesNameDaemonsetsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespacesName {
-           // Path templating
-           // Sub-paths
-           'replicasets': ApisExtensionsV1beta1WatchNamespacesNameReplicasets
-           'rs': ApisExtensionsV1beta1WatchNamespacesNameReplicasets
-           'replicaset': ApisExtensionsV1beta1WatchNamespacesNameReplicasets
-           'networkpolicies': ApisExtensionsV1beta1WatchNamespacesNameNetworkpolicies
-           'networkpolicie': ApisExtensionsV1beta1WatchNamespacesNameNetworkpolicies
-           'ingresses': ApisExtensionsV1beta1WatchNamespacesNameIngresses
-           'ing': ApisExtensionsV1beta1WatchNamespacesNameIngresses
-           'ingress': ApisExtensionsV1beta1WatchNamespacesNameIngresses
-           'deployments': ApisExtensionsV1beta1WatchNamespacesNameDeployments
-           'deploy': ApisExtensionsV1beta1WatchNamespacesNameDeployments
-           'deployment': ApisExtensionsV1beta1WatchNamespacesNameDeployments
-           'daemonsets': ApisExtensionsV1beta1WatchNamespacesNameDaemonsets
-           'ds': ApisExtensionsV1beta1WatchNamespacesNameDaemonsets
-           'daemonset': ApisExtensionsV1beta1WatchNamespacesNameDaemonsets
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNamespaces {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchPodsecuritypoliciesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchPodsecuritypolicies {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1WatchPodsecuritypoliciesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchDaemonsets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchDeployments {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchIngresses {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchNetworkpolicies {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1WatchReplicasets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1Watch {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisExtensionsV1beta1WatchNamespaces
-           'ns': ApisExtensionsV1beta1WatchNamespaces
-           'namespace': ApisExtensionsV1beta1WatchNamespaces
-           'podsecuritypolicies': ApisExtensionsV1beta1WatchPodsecuritypolicies
-           'podsecuritypolicie': ApisExtensionsV1beta1WatchPodsecuritypolicies
-           'daemonsets': ApisExtensionsV1beta1WatchDaemonsets
-           'ds': ApisExtensionsV1beta1WatchDaemonsets
-           'daemonset': ApisExtensionsV1beta1WatchDaemonsets
-           'deployments': ApisExtensionsV1beta1WatchDeployments
-           'deploy': ApisExtensionsV1beta1WatchDeployments
-           'deployment': ApisExtensionsV1beta1WatchDeployments
-           'ingresses': ApisExtensionsV1beta1WatchIngresses
-           'ing': ApisExtensionsV1beta1WatchIngresses
-           'ingress': ApisExtensionsV1beta1WatchIngresses
-           'networkpolicies': ApisExtensionsV1beta1WatchNetworkpolicies
-           'networkpolicie': ApisExtensionsV1beta1WatchNetworkpolicies
-           'replicasets': ApisExtensionsV1beta1WatchReplicasets
-           'rs': ApisExtensionsV1beta1WatchReplicasets
-           'replicaset': ApisExtensionsV1beta1WatchReplicasets
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameReplicationcontrollersNameScale {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameReplicationcontrollersName {
-           // Path templating
-           // Sub-paths
-           'scale': ApisExtensionsV1beta1NamespacesNameReplicationcontrollersNameScale
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameReplicationcontrollers {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1NamespacesNameReplicationcontrollersName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameReplicasetsNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameReplicasetsNameScale {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameReplicasetsName {
-           // Path templating
-           // Sub-paths
-           'status': ApisExtensionsV1beta1NamespacesNameReplicasetsNameStatus
-           'scale': ApisExtensionsV1beta1NamespacesNameReplicasetsNameScale
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameReplicasets {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1NamespacesNameReplicasetsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameIngressesNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameIngressesName {
-           // Path templating
-           // Sub-paths
-           'status': ApisExtensionsV1beta1NamespacesNameIngressesNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameIngresses {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1NamespacesNameIngressesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameDeploymentsNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameDeploymentsNameScale {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameDeploymentsNameRollback {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameDeploymentsName {
-           // Path templating
-           // Sub-paths
-           'status': ApisExtensionsV1beta1NamespacesNameDeploymentsNameStatus
-           'scale': ApisExtensionsV1beta1NamespacesNameDeploymentsNameScale
-           'rollback': ApisExtensionsV1beta1NamespacesNameDeploymentsNameRollback
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameDeployments {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1NamespacesNameDeploymentsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameDaemonsetsNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameDaemonsetsName {
-           // Path templating
-           // Sub-paths
-           'status': ApisExtensionsV1beta1NamespacesNameDaemonsetsNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameDaemonsets {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1NamespacesNameDaemonsetsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameNetworkpoliciesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesNameNetworkpolicies {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1NamespacesNameNetworkpoliciesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'replicationcontrollers': ApisExtensionsV1beta1NamespacesNameReplicationcontrollers
-           'rc': ApisExtensionsV1beta1NamespacesNameReplicationcontrollers
-           'replicationcontroller': ApisExtensionsV1beta1NamespacesNameReplicationcontrollers
-           'replicasets': ApisExtensionsV1beta1NamespacesNameReplicasets
-           'rs': ApisExtensionsV1beta1NamespacesNameReplicasets
-           'replicaset': ApisExtensionsV1beta1NamespacesNameReplicasets
-           'ingresses': ApisExtensionsV1beta1NamespacesNameIngresses
-           'ing': ApisExtensionsV1beta1NamespacesNameIngresses
-           'ingress': ApisExtensionsV1beta1NamespacesNameIngresses
-           'deployments': ApisExtensionsV1beta1NamespacesNameDeployments
-           'deploy': ApisExtensionsV1beta1NamespacesNameDeployments
-           'deployment': ApisExtensionsV1beta1NamespacesNameDeployments
-           'daemonsets': ApisExtensionsV1beta1NamespacesNameDaemonsets
-           'ds': ApisExtensionsV1beta1NamespacesNameDaemonsets
-           'daemonset': ApisExtensionsV1beta1NamespacesNameDaemonsets
-           'networkpolicies': ApisExtensionsV1beta1NamespacesNameNetworkpolicies
-           'networkpolicie': ApisExtensionsV1beta1NamespacesNameNetworkpolicies
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1Namespaces {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1NamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1PodsecuritypoliciesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1Podsecuritypolicies {
-           // Path templating
-           (name: string): ApisExtensionsV1beta1PodsecuritypoliciesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1Daemonsets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1Deployments {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1Ingresses {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1Networkpolicies {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1Replicasets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensionsV1beta1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisExtensionsV1beta1Watch
-           'namespaces': ApisExtensionsV1beta1Namespaces
-           'ns': ApisExtensionsV1beta1Namespaces
-           'namespace': ApisExtensionsV1beta1Namespaces
-           'podsecuritypolicies': ApisExtensionsV1beta1Podsecuritypolicies
-           'podsecuritypolicie': ApisExtensionsV1beta1Podsecuritypolicies
-           'daemonsets': ApisExtensionsV1beta1Daemonsets
-           'ds': ApisExtensionsV1beta1Daemonsets
-           'daemonset': ApisExtensionsV1beta1Daemonsets
-           'deployments': ApisExtensionsV1beta1Deployments
-           'deploy': ApisExtensionsV1beta1Deployments
-           'deployment': ApisExtensionsV1beta1Deployments
-           'ingresses': ApisExtensionsV1beta1Ingresses
-           'ing': ApisExtensionsV1beta1Ingresses
-           'ingress': ApisExtensionsV1beta1Ingresses
-           'networkpolicies': ApisExtensionsV1beta1Networkpolicies
-           'networkpolicie': ApisExtensionsV1beta1Networkpolicies
-           'replicasets': ApisExtensionsV1beta1Replicasets
-           'rs': ApisExtensionsV1beta1Replicasets
-           'replicaset': ApisExtensionsV1beta1Replicasets
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisExtensions {
-           // Path templating
-           // Sub-paths
-           'v1beta1': ApisExtensionsV1beta1
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
@@ -4099,6 +3525,138 @@ export interface ApisBatch {
            addCustomResourceDefinition(schema: object): void
        }
 
+export interface ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeasesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeases {
+           // Path templating
+           (name: string): ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeasesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1WatchNamespacesName {
+           // Path templating
+           // Sub-paths
+           'leases': ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeases
+           'lease': ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeases
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1WatchNamespaces {
+           // Path templating
+           (name: string): ApisCoordination_k8s_ioV1beta1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1WatchLeases {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisCoordination_k8s_ioV1beta1WatchNamespaces
+           'ns': ApisCoordination_k8s_ioV1beta1WatchNamespaces
+           'namespace': ApisCoordination_k8s_ioV1beta1WatchNamespaces
+           'leases': ApisCoordination_k8s_ioV1beta1WatchLeases
+           'lease': ApisCoordination_k8s_ioV1beta1WatchLeases
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1NamespacesNameLeasesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1NamespacesNameLeases {
+           // Path templating
+           (name: string): ApisCoordination_k8s_ioV1beta1NamespacesNameLeasesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'leases': ApisCoordination_k8s_ioV1beta1NamespacesNameLeases
+           'lease': ApisCoordination_k8s_ioV1beta1NamespacesNameLeases
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1Namespaces {
+           // Path templating
+           (name: string): ApisCoordination_k8s_ioV1beta1NamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1Leases {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_ioV1beta1 {
+           // Path templating
+           // Sub-paths
+           'watch': ApisCoordination_k8s_ioV1beta1Watch
+           'namespaces': ApisCoordination_k8s_ioV1beta1Namespaces
+           'ns': ApisCoordination_k8s_ioV1beta1Namespaces
+           'namespace': ApisCoordination_k8s_ioV1beta1Namespaces
+           'leases': ApisCoordination_k8s_ioV1beta1Leases
+           'lease': ApisCoordination_k8s_ioV1beta1Leases
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisCoordination_k8s_io {
+           // Path templating
+           // Sub-paths
+           'v1beta1': ApisCoordination_k8s_ioV1beta1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
 export interface ApisEvents_k8s_ioV1beta1WatchNamespacesNameEventsName {
            // Path templating
            // Sub-paths
@@ -4235,64 +3793,211 @@ export interface ApisEvents_k8s_io {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeasesName {
+export interface ApisExtensionsV1beta1NamespacesNameDaemonsetsNameStatus {
            // Path templating
            // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeases {
+export interface ApisExtensionsV1beta1NamespacesNameDaemonsetsName {
            // Path templating
-           (name: string): ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeasesName
+           // Sub-paths
+           'status': ApisExtensionsV1beta1NamespacesNameDaemonsetsNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameDaemonsets {
+           // Path templating
+           (name: string): ApisExtensionsV1beta1NamespacesNameDaemonsetsName
            // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1WatchNamespacesName {
+export interface ApisExtensionsV1beta1NamespacesNameDeploymentsNameRollback {
            // Path templating
            // Sub-paths
-           'leases': ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeases
-           'lease': ApisCoordination_k8s_ioV1beta1WatchNamespacesNameLeases
            // Calls
+           post(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1WatchNamespaces {
-           // Path templating
-           (name: string): ApisCoordination_k8s_ioV1beta1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisCoordination_k8s_ioV1beta1WatchLeases {
+export interface ApisExtensionsV1beta1NamespacesNameDeploymentsNameScale {
            // Path templating
            // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1Watch {
+export interface ApisExtensionsV1beta1NamespacesNameDeploymentsNameStatus {
            // Path templating
            // Sub-paths
-           'namespaces': ApisCoordination_k8s_ioV1beta1WatchNamespaces
-           'ns': ApisCoordination_k8s_ioV1beta1WatchNamespaces
-           'namespace': ApisCoordination_k8s_ioV1beta1WatchNamespaces
-           'leases': ApisCoordination_k8s_ioV1beta1WatchLeases
-           'lease': ApisCoordination_k8s_ioV1beta1WatchLeases
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameDeploymentsName {
+           // Path templating
+           // Sub-paths
+           'rollback': ApisExtensionsV1beta1NamespacesNameDeploymentsNameRollback
+           'scale': ApisExtensionsV1beta1NamespacesNameDeploymentsNameScale
+           'status': ApisExtensionsV1beta1NamespacesNameDeploymentsNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameDeployments {
+           // Path templating
+           (name: string): ApisExtensionsV1beta1NamespacesNameDeploymentsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameIngressesNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameIngressesName {
+           // Path templating
+           // Sub-paths
+           'status': ApisExtensionsV1beta1NamespacesNameIngressesNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameIngresses {
+           // Path templating
+           (name: string): ApisExtensionsV1beta1NamespacesNameIngressesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameReplicasetsNameScale {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameReplicasetsNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameReplicasetsName {
+           // Path templating
+           // Sub-paths
+           'scale': ApisExtensionsV1beta1NamespacesNameReplicasetsNameScale
+           'status': ApisExtensionsV1beta1NamespacesNameReplicasetsNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameReplicasets {
+           // Path templating
+           (name: string): ApisExtensionsV1beta1NamespacesNameReplicasetsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameReplicationcontrollersNameScale {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameReplicationcontrollersName {
+           // Path templating
+           // Sub-paths
+           'scale': ApisExtensionsV1beta1NamespacesNameReplicationcontrollersNameScale
            // Calls
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1NamespacesNameLeasesName {
+export interface ApisExtensionsV1beta1NamespacesNameReplicationcontrollers {
+           // Path templating
+           (name: string): ApisExtensionsV1beta1NamespacesNameReplicationcontrollersName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1NamespacesNameNetworkpoliciesName {
            // Path templating
            // Sub-paths
            // Calls
@@ -4304,9 +4009,9 @@ export interface ApisCoordination_k8s_ioV1beta1NamespacesNameLeasesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1NamespacesNameLeases {
+export interface ApisExtensionsV1beta1NamespacesNameNetworkpolicies {
            // Path templating
-           (name: string): ApisCoordination_k8s_ioV1beta1NamespacesNameLeasesName
+           (name: string): ApisExtensionsV1beta1NamespacesNameNetworkpoliciesName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4316,94 +4021,39 @@ export interface ApisCoordination_k8s_ioV1beta1NamespacesNameLeases {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1NamespacesName {
+export interface ApisExtensionsV1beta1NamespacesName {
            // Path templating
            // Sub-paths
-           'leases': ApisCoordination_k8s_ioV1beta1NamespacesNameLeases
-           'lease': ApisCoordination_k8s_ioV1beta1NamespacesNameLeases
+           'daemonsets': ApisExtensionsV1beta1NamespacesNameDaemonsets
+           'ds': ApisExtensionsV1beta1NamespacesNameDaemonsets
+           'daemonset': ApisExtensionsV1beta1NamespacesNameDaemonsets
+           'deployments': ApisExtensionsV1beta1NamespacesNameDeployments
+           'deploy': ApisExtensionsV1beta1NamespacesNameDeployments
+           'deployment': ApisExtensionsV1beta1NamespacesNameDeployments
+           'ingresses': ApisExtensionsV1beta1NamespacesNameIngresses
+           'ing': ApisExtensionsV1beta1NamespacesNameIngresses
+           'ingress': ApisExtensionsV1beta1NamespacesNameIngresses
+           'replicasets': ApisExtensionsV1beta1NamespacesNameReplicasets
+           'rs': ApisExtensionsV1beta1NamespacesNameReplicasets
+           'replicaset': ApisExtensionsV1beta1NamespacesNameReplicasets
+           'replicationcontrollers': ApisExtensionsV1beta1NamespacesNameReplicationcontrollers
+           'rc': ApisExtensionsV1beta1NamespacesNameReplicationcontrollers
+           'replicationcontroller': ApisExtensionsV1beta1NamespacesNameReplicationcontrollers
+           'networkpolicies': ApisExtensionsV1beta1NamespacesNameNetworkpolicies
+           'networkpolicie': ApisExtensionsV1beta1NamespacesNameNetworkpolicies
            // Calls
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1Namespaces {
+export interface ApisExtensionsV1beta1Namespaces {
            // Path templating
-           (name: string): ApisCoordination_k8s_ioV1beta1NamespacesName
+           (name: string): ApisExtensionsV1beta1NamespacesName
            // Sub-paths
            // Calls
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisCoordination_k8s_ioV1beta1Leases {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisCoordination_k8s_ioV1beta1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisCoordination_k8s_ioV1beta1Watch
-           'namespaces': ApisCoordination_k8s_ioV1beta1Namespaces
-           'ns': ApisCoordination_k8s_ioV1beta1Namespaces
-           'namespace': ApisCoordination_k8s_ioV1beta1Namespaces
-           'leases': ApisCoordination_k8s_ioV1beta1Leases
-           'lease': ApisCoordination_k8s_ioV1beta1Leases
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisCoordination_k8s_io {
-           // Path templating
-           // Sub-paths
-           'v1beta1': ApisCoordination_k8s_ioV1beta1
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1ApiservicesNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1ApiservicesName {
-           // Path templating
-           // Sub-paths
-           'status': ApisApiregistration_k8s_ioV1ApiservicesNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1Apiservices {
-           // Path templating
-           (name: string): ApisApiregistration_k8s_ioV1ApiservicesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1WatchApiservicesName {
+export interface ApisExtensionsV1beta1WatchNamespacesNameDaemonsetsName {
            // Path templating
            // Sub-paths
            // Calls
@@ -4412,9 +4062,9 @@ export interface ApisApiregistration_k8s_ioV1WatchApiservicesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiregistration_k8s_ioV1WatchApiservices {
+export interface ApisExtensionsV1beta1WatchNamespacesNameDaemonsets {
            // Path templating
-           (name: string): ApisApiregistration_k8s_ioV1WatchApiservicesName
+           (name: string): ApisExtensionsV1beta1WatchNamespacesNameDaemonsetsName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4422,64 +4072,7 @@ export interface ApisApiregistration_k8s_ioV1WatchApiservices {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiregistration_k8s_ioV1Watch {
-           // Path templating
-           // Sub-paths
-           'apiservices': ApisApiregistration_k8s_ioV1WatchApiservices
-           'apiservice': ApisApiregistration_k8s_ioV1WatchApiservices
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1 {
-           // Path templating
-           // Sub-paths
-           'apiservices': ApisApiregistration_k8s_ioV1Apiservices
-           'apiservice': ApisApiregistration_k8s_ioV1Apiservices
-           'watch': ApisApiregistration_k8s_ioV1Watch
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1beta1ApiservicesNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1beta1ApiservicesName {
-           // Path templating
-           // Sub-paths
-           'status': ApisApiregistration_k8s_ioV1beta1ApiservicesNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1beta1Apiservices {
-           // Path templating
-           (name: string): ApisApiregistration_k8s_ioV1beta1ApiservicesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1beta1WatchApiservicesName {
+export interface ApisExtensionsV1beta1WatchNamespacesNameDeploymentsName {
            // Path templating
            // Sub-paths
            // Calls
@@ -4488,9 +4081,9 @@ export interface ApisApiregistration_k8s_ioV1beta1WatchApiservicesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiregistration_k8s_ioV1beta1WatchApiservices {
+export interface ApisExtensionsV1beta1WatchNamespacesNameDeployments {
            // Path templating
-           (name: string): ApisApiregistration_k8s_ioV1beta1WatchApiservicesName
+           (name: string): ApisExtensionsV1beta1WatchNamespacesNameDeploymentsName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4498,39 +4091,7 @@ export interface ApisApiregistration_k8s_ioV1beta1WatchApiservices {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiregistration_k8s_ioV1beta1Watch {
-           // Path templating
-           // Sub-paths
-           'apiservices': ApisApiregistration_k8s_ioV1beta1WatchApiservices
-           'apiservice': ApisApiregistration_k8s_ioV1beta1WatchApiservices
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_ioV1beta1 {
-           // Path templating
-           // Sub-paths
-           'apiservices': ApisApiregistration_k8s_ioV1beta1Apiservices
-           'apiservice': ApisApiregistration_k8s_ioV1beta1Apiservices
-           'watch': ApisApiregistration_k8s_ioV1beta1Watch
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisApiregistration_k8s_io {
-           // Path templating
-           // Sub-paths
-           'v1': ApisApiregistration_k8s_ioV1
-           'v1beta1': ApisApiregistration_k8s_ioV1beta1
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1alpha1WatchVolumeattachmentsName {
+export interface ApisExtensionsV1beta1WatchNamespacesNameIngressesName {
            // Path templating
            // Sub-paths
            // Calls
@@ -4539,9 +4100,9 @@ export interface ApisStorage_k8s_ioV1alpha1WatchVolumeattachmentsName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1alpha1WatchVolumeattachments {
+export interface ApisExtensionsV1beta1WatchNamespacesNameIngresses {
            // Path templating
-           (name: string): ApisStorage_k8s_ioV1alpha1WatchVolumeattachmentsName
+           (name: string): ApisExtensionsV1beta1WatchNamespacesNameIngressesName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4549,52 +4110,7 @@ export interface ApisStorage_k8s_ioV1alpha1WatchVolumeattachments {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1alpha1Watch {
-           // Path templating
-           // Sub-paths
-           'volumeattachments': ApisStorage_k8s_ioV1alpha1WatchVolumeattachments
-           'volumeattachment': ApisStorage_k8s_ioV1alpha1WatchVolumeattachments
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1alpha1VolumeattachmentsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1alpha1Volumeattachments {
-           // Path templating
-           (name: string): ApisStorage_k8s_ioV1alpha1VolumeattachmentsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1alpha1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisStorage_k8s_ioV1alpha1Watch
-           'volumeattachments': ApisStorage_k8s_ioV1alpha1Volumeattachments
-           'volumeattachment': ApisStorage_k8s_ioV1alpha1Volumeattachments
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1WatchVolumeattachmentsName {
+export interface ApisExtensionsV1beta1WatchNamespacesNameNetworkpoliciesName {
            // Path templating
            // Sub-paths
            // Calls
@@ -4603,9 +4119,9 @@ export interface ApisStorage_k8s_ioV1WatchVolumeattachmentsName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1WatchVolumeattachments {
+export interface ApisExtensionsV1beta1WatchNamespacesNameNetworkpolicies {
            // Path templating
-           (name: string): ApisStorage_k8s_ioV1WatchVolumeattachmentsName
+           (name: string): ApisExtensionsV1beta1WatchNamespacesNameNetworkpoliciesName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4613,7 +4129,7 @@ export interface ApisStorage_k8s_ioV1WatchVolumeattachments {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1WatchStorageclassesName {
+export interface ApisExtensionsV1beta1WatchNamespacesNameReplicasetsName {
            // Path templating
            // Sub-paths
            // Calls
@@ -4622,9 +4138,9 @@ export interface ApisStorage_k8s_ioV1WatchStorageclassesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1WatchStorageclasses {
+export interface ApisExtensionsV1beta1WatchNamespacesNameReplicasets {
            // Path templating
-           (name: string): ApisStorage_k8s_ioV1WatchStorageclassesName
+           (name: string): ApisExtensionsV1beta1WatchNamespacesNameReplicasetsName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4632,54 +4148,126 @@ export interface ApisStorage_k8s_ioV1WatchStorageclasses {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1Watch {
+export interface ApisExtensionsV1beta1WatchNamespacesName {
            // Path templating
            // Sub-paths
-           'volumeattachments': ApisStorage_k8s_ioV1WatchVolumeattachments
-           'volumeattachment': ApisStorage_k8s_ioV1WatchVolumeattachments
-           'storageclasses': ApisStorage_k8s_ioV1WatchStorageclasses
-           'storageclasse': ApisStorage_k8s_ioV1WatchStorageclasses
+           'daemonsets': ApisExtensionsV1beta1WatchNamespacesNameDaemonsets
+           'ds': ApisExtensionsV1beta1WatchNamespacesNameDaemonsets
+           'daemonset': ApisExtensionsV1beta1WatchNamespacesNameDaemonsets
+           'deployments': ApisExtensionsV1beta1WatchNamespacesNameDeployments
+           'deploy': ApisExtensionsV1beta1WatchNamespacesNameDeployments
+           'deployment': ApisExtensionsV1beta1WatchNamespacesNameDeployments
+           'ingresses': ApisExtensionsV1beta1WatchNamespacesNameIngresses
+           'ing': ApisExtensionsV1beta1WatchNamespacesNameIngresses
+           'ingress': ApisExtensionsV1beta1WatchNamespacesNameIngresses
+           'networkpolicies': ApisExtensionsV1beta1WatchNamespacesNameNetworkpolicies
+           'networkpolicie': ApisExtensionsV1beta1WatchNamespacesNameNetworkpolicies
+           'replicasets': ApisExtensionsV1beta1WatchNamespacesNameReplicasets
+           'rs': ApisExtensionsV1beta1WatchNamespacesNameReplicasets
+           'replicaset': ApisExtensionsV1beta1WatchNamespacesNameReplicasets
            // Calls
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1VolumeattachmentsNameStatus {
+export interface ApisExtensionsV1beta1WatchNamespaces {
+           // Path templating
+           (name: string): ApisExtensionsV1beta1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1WatchPodsecuritypoliciesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1WatchPodsecuritypolicies {
+           // Path templating
+           (name: string): ApisExtensionsV1beta1WatchPodsecuritypoliciesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1WatchDaemonsets {
            // Path templating
            // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1VolumeattachmentsName {
+export interface ApisExtensionsV1beta1WatchDeployments {
            // Path templating
-           // Sub-paths
-           'status': ApisStorage_k8s_ioV1VolumeattachmentsNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1Volumeattachments {
-           // Path templating
-           (name: string): ApisStorage_k8s_ioV1VolumeattachmentsName
            // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1StorageclassesName {
+export interface ApisExtensionsV1beta1WatchIngresses {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1WatchNetworkpolicies {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1WatchReplicasets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisExtensionsV1beta1WatchNamespaces
+           'ns': ApisExtensionsV1beta1WatchNamespaces
+           'namespace': ApisExtensionsV1beta1WatchNamespaces
+           'podsecuritypolicies': ApisExtensionsV1beta1WatchPodsecuritypolicies
+           'podsecuritypolicie': ApisExtensionsV1beta1WatchPodsecuritypolicies
+           'daemonsets': ApisExtensionsV1beta1WatchDaemonsets
+           'ds': ApisExtensionsV1beta1WatchDaemonsets
+           'daemonset': ApisExtensionsV1beta1WatchDaemonsets
+           'deployments': ApisExtensionsV1beta1WatchDeployments
+           'deploy': ApisExtensionsV1beta1WatchDeployments
+           'deployment': ApisExtensionsV1beta1WatchDeployments
+           'ingresses': ApisExtensionsV1beta1WatchIngresses
+           'ing': ApisExtensionsV1beta1WatchIngresses
+           'ingress': ApisExtensionsV1beta1WatchIngresses
+           'networkpolicies': ApisExtensionsV1beta1WatchNetworkpolicies
+           'networkpolicie': ApisExtensionsV1beta1WatchNetworkpolicies
+           'replicasets': ApisExtensionsV1beta1WatchReplicasets
+           'rs': ApisExtensionsV1beta1WatchReplicasets
+           'replicaset': ApisExtensionsV1beta1WatchReplicasets
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1PodsecuritypoliciesName {
            // Path templating
            // Sub-paths
            // Calls
@@ -4691,9 +4279,9 @@ export interface ApisStorage_k8s_ioV1StorageclassesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1Storageclasses {
+export interface ApisExtensionsV1beta1Podsecuritypolicies {
            // Path templating
-           (name: string): ApisStorage_k8s_ioV1StorageclassesName
+           (name: string): ApisExtensionsV1beta1PodsecuritypoliciesName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4703,21 +4291,7 @@ export interface ApisStorage_k8s_ioV1Storageclasses {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisStorage_k8s_ioV1Watch
-           'volumeattachments': ApisStorage_k8s_ioV1Volumeattachments
-           'volumeattachment': ApisStorage_k8s_ioV1Volumeattachments
-           'storageclasses': ApisStorage_k8s_ioV1Storageclasses
-           'storageclasse': ApisStorage_k8s_ioV1Storageclasses
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1beta1WatchVolumeattachmentsName {
+export interface ApisExtensionsV1beta1Daemonsets {
            // Path templating
            // Sub-paths
            // Calls
@@ -4726,17 +4300,7 @@ export interface ApisStorage_k8s_ioV1beta1WatchVolumeattachmentsName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1beta1WatchVolumeattachments {
-           // Path templating
-           (name: string): ApisStorage_k8s_ioV1beta1WatchVolumeattachmentsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1beta1WatchStorageclassesName {
+export interface ApisExtensionsV1beta1Deployments {
            // Path templating
            // Sub-paths
            // Calls
@@ -4745,102 +4309,7 @@ export interface ApisStorage_k8s_ioV1beta1WatchStorageclassesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisStorage_k8s_ioV1beta1WatchStorageclasses {
-           // Path templating
-           (name: string): ApisStorage_k8s_ioV1beta1WatchStorageclassesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1beta1Watch {
-           // Path templating
-           // Sub-paths
-           'volumeattachments': ApisStorage_k8s_ioV1beta1WatchVolumeattachments
-           'volumeattachment': ApisStorage_k8s_ioV1beta1WatchVolumeattachments
-           'storageclasses': ApisStorage_k8s_ioV1beta1WatchStorageclasses
-           'storageclasse': ApisStorage_k8s_ioV1beta1WatchStorageclasses
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1beta1StorageclassesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1beta1Storageclasses {
-           // Path templating
-           (name: string): ApisStorage_k8s_ioV1beta1StorageclassesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1beta1VolumeattachmentsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1beta1Volumeattachments {
-           // Path templating
-           (name: string): ApisStorage_k8s_ioV1beta1VolumeattachmentsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_ioV1beta1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisStorage_k8s_ioV1beta1Watch
-           'storageclasses': ApisStorage_k8s_ioV1beta1Storageclasses
-           'storageclasse': ApisStorage_k8s_ioV1beta1Storageclasses
-           'volumeattachments': ApisStorage_k8s_ioV1beta1Volumeattachments
-           'volumeattachment': ApisStorage_k8s_ioV1beta1Volumeattachments
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisStorage_k8s_io {
-           // Path templating
-           // Sub-paths
-           'v1alpha1': ApisStorage_k8s_ioV1alpha1
-           'v1': ApisStorage_k8s_ioV1
-           'v1beta1': ApisStorage_k8s_ioV1beta1
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinksName {
+export interface ApisExtensionsV1beta1Ingresses {
            // Path templating
            // Sub-paths
            // Calls
@@ -4849,9 +4318,8 @@ export interface ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinksName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinks {
+export interface ApisExtensionsV1beta1Networkpolicies {
            // Path templating
-           (name: string): ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinksName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4859,16 +4327,112 @@ export interface ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinks {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAuditregistration_k8s_ioV1alpha1Watch {
+export interface ApisExtensionsV1beta1Replicasets {
            // Path templating
            // Sub-paths
-           'auditsinks': ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinks
-           'auditsink': ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinks
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensionsV1beta1 {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisExtensionsV1beta1Namespaces
+           'ns': ApisExtensionsV1beta1Namespaces
+           'namespace': ApisExtensionsV1beta1Namespaces
+           'watch': ApisExtensionsV1beta1Watch
+           'podsecuritypolicies': ApisExtensionsV1beta1Podsecuritypolicies
+           'podsecuritypolicie': ApisExtensionsV1beta1Podsecuritypolicies
+           'daemonsets': ApisExtensionsV1beta1Daemonsets
+           'ds': ApisExtensionsV1beta1Daemonsets
+           'daemonset': ApisExtensionsV1beta1Daemonsets
+           'deployments': ApisExtensionsV1beta1Deployments
+           'deploy': ApisExtensionsV1beta1Deployments
+           'deployment': ApisExtensionsV1beta1Deployments
+           'ingresses': ApisExtensionsV1beta1Ingresses
+           'ing': ApisExtensionsV1beta1Ingresses
+           'ingress': ApisExtensionsV1beta1Ingresses
+           'networkpolicies': ApisExtensionsV1beta1Networkpolicies
+           'networkpolicie': ApisExtensionsV1beta1Networkpolicies
+           'replicasets': ApisExtensionsV1beta1Replicasets
+           'rs': ApisExtensionsV1beta1Replicasets
+           'replicaset': ApisExtensionsV1beta1Replicasets
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisExtensions {
+           // Path templating
+           // Sub-paths
+           'v1beta1': ApisExtensionsV1beta1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpoliciesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpolicies {
+           // Path templating
+           (name: string): ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpoliciesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisNetworking_k8s_ioV1WatchNamespacesName {
+           // Path templating
+           // Sub-paths
+           'networkpolicies': ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpolicies
+           'networkpolicie': ApisNetworking_k8s_ioV1WatchNamespacesNameNetworkpolicies
            // Calls
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAuditregistration_k8s_ioV1alpha1AuditsinksName {
+export interface ApisNetworking_k8s_ioV1WatchNamespaces {
+           // Path templating
+           (name: string): ApisNetworking_k8s_ioV1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisNetworking_k8s_ioV1WatchNetworkpolicies {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisNetworking_k8s_ioV1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisNetworking_k8s_ioV1WatchNamespaces
+           'ns': ApisNetworking_k8s_ioV1WatchNamespaces
+           'namespace': ApisNetworking_k8s_ioV1WatchNamespaces
+           'networkpolicies': ApisNetworking_k8s_ioV1WatchNetworkpolicies
+           'networkpolicie': ApisNetworking_k8s_ioV1WatchNetworkpolicies
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisNetworking_k8s_ioV1NamespacesNameNetworkpoliciesName {
            // Path templating
            // Sub-paths
            // Calls
@@ -4880,9 +4444,9 @@ export interface ApisAuditregistration_k8s_ioV1alpha1AuditsinksName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAuditregistration_k8s_ioV1alpha1Auditsinks {
+export interface ApisNetworking_k8s_ioV1NamespacesNameNetworkpolicies {
            // Path templating
-           (name: string): ApisAuditregistration_k8s_ioV1alpha1AuditsinksName
+           (name: string): ApisNetworking_k8s_ioV1NamespacesNameNetworkpoliciesName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4892,29 +4456,24 @@ export interface ApisAuditregistration_k8s_ioV1alpha1Auditsinks {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAuditregistration_k8s_ioV1alpha1 {
+export interface ApisNetworking_k8s_ioV1NamespacesName {
            // Path templating
            // Sub-paths
-           'watch': ApisAuditregistration_k8s_ioV1alpha1Watch
-           'auditsinks': ApisAuditregistration_k8s_ioV1alpha1Auditsinks
-           'auditsink': ApisAuditregistration_k8s_ioV1alpha1Auditsinks
+           'networkpolicies': ApisNetworking_k8s_ioV1NamespacesNameNetworkpolicies
+           'networkpolicie': ApisNetworking_k8s_ioV1NamespacesNameNetworkpolicies
            // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAuditregistration_k8s_io {
+export interface ApisNetworking_k8s_ioV1Namespaces {
            // Path templating
+           (name: string): ApisNetworking_k8s_ioV1NamespacesName
            // Sub-paths
-           'v1alpha1': ApisAuditregistration_k8s_ioV1alpha1
            // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1beta1WatchPriorityclassesName {
+export interface ApisNetworking_k8s_ioV1Networkpolicies {
            // Path templating
            // Sub-paths
            // Calls
@@ -4923,9 +4482,86 @@ export interface ApisScheduling_k8s_ioV1beta1WatchPriorityclassesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1beta1WatchPriorityclasses {
+export interface ApisNetworking_k8s_ioV1 {
            // Path templating
-           (name: string): ApisScheduling_k8s_ioV1beta1WatchPriorityclassesName
+           // Sub-paths
+           'watch': ApisNetworking_k8s_ioV1Watch
+           'namespaces': ApisNetworking_k8s_ioV1Namespaces
+           'ns': ApisNetworking_k8s_ioV1Namespaces
+           'namespace': ApisNetworking_k8s_ioV1Namespaces
+           'networkpolicies': ApisNetworking_k8s_ioV1Networkpolicies
+           'networkpolicie': ApisNetworking_k8s_ioV1Networkpolicies
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisNetworking_k8s_io {
+           // Path templating
+           // Sub-paths
+           'v1': ApisNetworking_k8s_ioV1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1NamespacesNamePoddisruptionbudgetsNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1NamespacesNamePoddisruptionbudgetsName {
+           // Path templating
+           // Sub-paths
+           'status': ApisPolicyV1beta1NamespacesNamePoddisruptionbudgetsNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1NamespacesNamePoddisruptionbudgets {
+           // Path templating
+           (name: string): ApisPolicyV1beta1NamespacesNamePoddisruptionbudgetsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'poddisruptionbudgets': ApisPolicyV1beta1NamespacesNamePoddisruptionbudgets
+           'poddisruptionbudget': ApisPolicyV1beta1NamespacesNamePoddisruptionbudgets
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1Namespaces {
+           // Path templating
+           (name: string): ApisPolicyV1beta1NamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgetsName {
+           // Path templating
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4933,16 +4569,76 @@ export interface ApisScheduling_k8s_ioV1beta1WatchPriorityclasses {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1beta1Watch {
+export interface ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgets {
+           // Path templating
+           (name: string): ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgetsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1WatchNamespacesName {
            // Path templating
            // Sub-paths
-           'priorityclasses': ApisScheduling_k8s_ioV1beta1WatchPriorityclasses
-           'priorityclasse': ApisScheduling_k8s_ioV1beta1WatchPriorityclasses
+           'poddisruptionbudgets': ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgets
+           'poddisruptionbudget': ApisPolicyV1beta1WatchNamespacesNamePoddisruptionbudgets
            // Calls
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1beta1PriorityclassesName {
+export interface ApisPolicyV1beta1WatchNamespaces {
+           // Path templating
+           (name: string): ApisPolicyV1beta1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1WatchPodsecuritypoliciesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1WatchPodsecuritypolicies {
+           // Path templating
+           (name: string): ApisPolicyV1beta1WatchPodsecuritypoliciesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1WatchPoddisruptionbudgets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisPolicyV1beta1WatchNamespaces
+           'ns': ApisPolicyV1beta1WatchNamespaces
+           'namespace': ApisPolicyV1beta1WatchNamespaces
+           'podsecuritypolicies': ApisPolicyV1beta1WatchPodsecuritypolicies
+           'podsecuritypolicie': ApisPolicyV1beta1WatchPodsecuritypolicies
+           'poddisruptionbudgets': ApisPolicyV1beta1WatchPoddisruptionbudgets
+           'poddisruptionbudget': ApisPolicyV1beta1WatchPoddisruptionbudgets
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicyV1beta1PodsecuritypoliciesName {
            // Path templating
            // Sub-paths
            // Calls
@@ -4954,9 +4650,9 @@ export interface ApisScheduling_k8s_ioV1beta1PriorityclassesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1beta1Priorityclasses {
+export interface ApisPolicyV1beta1Podsecuritypolicies {
            // Path templating
-           (name: string): ApisScheduling_k8s_ioV1beta1PriorityclassesName
+           (name: string): ApisPolicyV1beta1PodsecuritypoliciesName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4966,19 +4662,7 @@ export interface ApisScheduling_k8s_ioV1beta1Priorityclasses {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1beta1 {
-           // Path templating
-           // Sub-paths
-           'watch': ApisScheduling_k8s_ioV1beta1Watch
-           'priorityclasses': ApisScheduling_k8s_ioV1beta1Priorityclasses
-           'priorityclasse': ApisScheduling_k8s_ioV1beta1Priorityclasses
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisScheduling_k8s_ioV1alpha1WatchPriorityclassesName {
+export interface ApisPolicyV1beta1Poddisruptionbudgets {
            // Path templating
            // Sub-paths
            // Calls
@@ -4987,9 +4671,35 @@ export interface ApisScheduling_k8s_ioV1alpha1WatchPriorityclassesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1alpha1WatchPriorityclasses {
+export interface ApisPolicyV1beta1 {
            // Path templating
-           (name: string): ApisScheduling_k8s_ioV1alpha1WatchPriorityclassesName
+           // Sub-paths
+           'namespaces': ApisPolicyV1beta1Namespaces
+           'ns': ApisPolicyV1beta1Namespaces
+           'namespace': ApisPolicyV1beta1Namespaces
+           'watch': ApisPolicyV1beta1Watch
+           'podsecuritypolicies': ApisPolicyV1beta1Podsecuritypolicies
+           'podsecuritypolicie': ApisPolicyV1beta1Podsecuritypolicies
+           'poddisruptionbudgets': ApisPolicyV1beta1Poddisruptionbudgets
+           'poddisruptionbudget': ApisPolicyV1beta1Poddisruptionbudgets
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisPolicy {
+           // Path templating
+           // Sub-paths
+           'v1beta1': ApisPolicyV1beta1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindingsName {
+           // Path templating
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -4997,16 +4707,129 @@ export interface ApisScheduling_k8s_ioV1alpha1WatchPriorityclasses {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1alpha1Watch {
+export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolesName {
            // Path templating
            // Sub-paths
-           'priorityclasses': ApisScheduling_k8s_ioV1alpha1WatchPriorityclasses
-           'priorityclasse': ApisScheduling_k8s_ioV1alpha1WatchPriorityclasses
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRoles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchNamespacesName {
+           // Path templating
+           // Sub-paths
+           'rolebindings': ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRoles
+           'role': ApisRbac_authorization_k8s_ioV1WatchNamespacesNameRoles
            // Calls
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1alpha1PriorityclassesName {
+export interface ApisRbac_authorization_k8s_ioV1WatchNamespaces {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchClusterrolebindingsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchClusterrolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1WatchClusterrolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchClusterrolesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchClusterroles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1WatchClusterrolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchRolebindings {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1WatchRoles {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisRbac_authorization_k8s_ioV1WatchNamespaces
+           'ns': ApisRbac_authorization_k8s_ioV1WatchNamespaces
+           'namespace': ApisRbac_authorization_k8s_ioV1WatchNamespaces
+           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1WatchClusterrolebindings
+           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1WatchClusterrolebindings
+           'clusterroles': ApisRbac_authorization_k8s_ioV1WatchClusterroles
+           'clusterrole': ApisRbac_authorization_k8s_ioV1WatchClusterroles
+           'rolebindings': ApisRbac_authorization_k8s_ioV1WatchRolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1WatchRolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1WatchRoles
+           'role': ApisRbac_authorization_k8s_ioV1WatchRoles
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindingsName {
            // Path templating
            // Sub-paths
            // Calls
@@ -5018,9 +4841,9 @@ export interface ApisScheduling_k8s_ioV1alpha1PriorityclassesName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1alpha1Priorityclasses {
+export interface ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindings {
            // Path templating
-           (name: string): ApisScheduling_k8s_ioV1alpha1PriorityclassesName
+           (name: string): ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindingsName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -5030,168 +4853,844 @@ export interface ApisScheduling_k8s_ioV1alpha1Priorityclasses {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_ioV1alpha1 {
+export interface ApisRbac_authorization_k8s_ioV1NamespacesNameRolesName {
            // Path templating
            // Sub-paths
-           'watch': ApisScheduling_k8s_ioV1alpha1Watch
-           'priorityclasses': ApisScheduling_k8s_ioV1alpha1Priorityclasses
-           'priorityclasse': ApisScheduling_k8s_ioV1alpha1Priorityclasses
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1NamespacesNameRoles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1NamespacesNameRolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'rolebindings': ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1NamespacesNameRolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1NamespacesNameRoles
+           'role': ApisRbac_authorization_k8s_ioV1NamespacesNameRoles
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1Namespaces {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1NamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1ClusterrolebindingsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1Clusterrolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1ClusterrolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1ClusterrolesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1Clusterroles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1ClusterrolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1Rolebindings {
+           // Path templating
+           // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisScheduling_k8s_io {
+export interface ApisRbac_authorization_k8s_ioV1Roles {
            // Path templating
            // Sub-paths
-           'v1beta1': ApisScheduling_k8s_ioV1beta1
-           'v1alpha1': ApisScheduling_k8s_ioV1alpha1
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAuthorization_k8s_ioV1NamespacesNameLocalsubjectaccessreviews {
+export interface ApisRbac_authorization_k8s_ioV1 {
            // Path templating
            // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'localsubjectaccessreviews': ApisAuthorization_k8s_ioV1NamespacesNameLocalsubjectaccessreviews
-           'localsubjectaccessreview': ApisAuthorization_k8s_ioV1NamespacesNameLocalsubjectaccessreviews
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1Namespaces {
-           // Path templating
-           (name: string): ApisAuthorization_k8s_ioV1NamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1Selfsubjectaccessreviews {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1Selfsubjectrulesreviews {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1Subjectaccessreviews {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1 {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisAuthorization_k8s_ioV1Namespaces
-           'ns': ApisAuthorization_k8s_ioV1Namespaces
-           'namespace': ApisAuthorization_k8s_ioV1Namespaces
-           'selfsubjectaccessreviews': ApisAuthorization_k8s_ioV1Selfsubjectaccessreviews
-           'selfsubjectaccessreview': ApisAuthorization_k8s_ioV1Selfsubjectaccessreviews
-           'selfsubjectrulesreviews': ApisAuthorization_k8s_ioV1Selfsubjectrulesreviews
-           'selfsubjectrulesreview': ApisAuthorization_k8s_ioV1Selfsubjectrulesreviews
-           'subjectaccessreviews': ApisAuthorization_k8s_ioV1Subjectaccessreviews
-           'subjectaccessreview': ApisAuthorization_k8s_ioV1Subjectaccessreviews
+           'watch': ApisRbac_authorization_k8s_ioV1Watch
+           'namespaces': ApisRbac_authorization_k8s_ioV1Namespaces
+           'ns': ApisRbac_authorization_k8s_ioV1Namespaces
+           'namespace': ApisRbac_authorization_k8s_ioV1Namespaces
+           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1Clusterrolebindings
+           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1Clusterrolebindings
+           'clusterroles': ApisRbac_authorization_k8s_ioV1Clusterroles
+           'clusterrole': ApisRbac_authorization_k8s_ioV1Clusterroles
+           'rolebindings': ApisRbac_authorization_k8s_ioV1Rolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1Rolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1Roles
+           'role': ApisRbac_authorization_k8s_ioV1Roles
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAuthorization_k8s_ioV1beta1NamespacesNameLocalsubjectaccessreviews {
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindingsName {
            // Path templating
            // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1beta1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'localsubjectaccessreviews': ApisAuthorization_k8s_ioV1beta1NamespacesNameLocalsubjectaccessreviews
-           'localsubjectaccessreview': ApisAuthorization_k8s_ioV1beta1NamespacesNameLocalsubjectaccessreviews
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1beta1Namespaces {
-           // Path templating
-           (name: string): ApisAuthorization_k8s_ioV1beta1NamespacesName
-           // Sub-paths
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1beta1Selfsubjectaccessreviews {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1beta1Selfsubjectrulesreviews {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1beta1Subjectaccessreviews {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApisAuthorization_k8s_ioV1beta1 {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApisAuthorization_k8s_ioV1beta1Namespaces
-           'ns': ApisAuthorization_k8s_ioV1beta1Namespaces
-           'namespace': ApisAuthorization_k8s_ioV1beta1Namespaces
-           'selfsubjectaccessreviews': ApisAuthorization_k8s_ioV1beta1Selfsubjectaccessreviews
-           'selfsubjectaccessreview': ApisAuthorization_k8s_ioV1beta1Selfsubjectaccessreviews
-           'selfsubjectrulesreviews': ApisAuthorization_k8s_ioV1beta1Selfsubjectrulesreviews
-           'selfsubjectrulesreview': ApisAuthorization_k8s_ioV1beta1Selfsubjectrulesreviews
-           'subjectaccessreviews': ApisAuthorization_k8s_ioV1beta1Subjectaccessreviews
-           'subjectaccessreview': ApisAuthorization_k8s_ioV1beta1Subjectaccessreviews
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisAuthorization_k8s_io {
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolesName {
            // Path templating
            // Sub-paths
-           'v1': ApisAuthorization_k8s_ioV1
-           'v1beta1': ApisAuthorization_k8s_ioV1beta1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRoles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesName {
+           // Path templating
+           // Sub-paths
+           'rolebindings': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRoles
+           'role': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesNameRoles
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchNamespaces {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindingsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchClusterroles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchRolebindings {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1WatchRoles {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespaces
+           'ns': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespaces
+           'namespace': ApisRbac_authorization_k8s_ioV1alpha1WatchNamespaces
+           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindings
+           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1alpha1WatchClusterrolebindings
+           'clusterroles': ApisRbac_authorization_k8s_ioV1alpha1WatchClusterroles
+           'clusterrole': ApisRbac_authorization_k8s_ioV1alpha1WatchClusterroles
+           'rolebindings': ApisRbac_authorization_k8s_ioV1alpha1WatchRolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1alpha1WatchRolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1alpha1WatchRoles
+           'role': ApisRbac_authorization_k8s_ioV1alpha1WatchRoles
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindingsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRoles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'rolebindings': ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRoles
+           'role': ApisRbac_authorization_k8s_ioV1alpha1NamespacesNameRoles
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1Namespaces {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1NamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1ClusterrolebindingsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1Clusterrolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1ClusterrolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1ClusterrolesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1Clusterroles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1alpha1ClusterrolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1Rolebindings {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1Roles {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1alpha1 {
+           // Path templating
+           // Sub-paths
+           'watch': ApisRbac_authorization_k8s_ioV1alpha1Watch
+           'namespaces': ApisRbac_authorization_k8s_ioV1alpha1Namespaces
+           'ns': ApisRbac_authorization_k8s_ioV1alpha1Namespaces
+           'namespace': ApisRbac_authorization_k8s_ioV1alpha1Namespaces
+           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1alpha1Clusterrolebindings
+           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1alpha1Clusterrolebindings
+           'clusterroles': ApisRbac_authorization_k8s_ioV1alpha1Clusterroles
+           'clusterrole': ApisRbac_authorization_k8s_ioV1alpha1Clusterroles
+           'rolebindings': ApisRbac_authorization_k8s_ioV1alpha1Rolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1alpha1Rolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1alpha1Roles
+           'role': ApisRbac_authorization_k8s_ioV1alpha1Roles
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindingsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRoles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesName {
+           // Path templating
+           // Sub-paths
+           'rolebindings': ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRoles
+           'role': ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesNameRoles
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchNamespaces {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindingsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchClusterroles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchRolebindings {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1WatchRoles {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisRbac_authorization_k8s_ioV1beta1WatchNamespaces
+           'ns': ApisRbac_authorization_k8s_ioV1beta1WatchNamespaces
+           'namespace': ApisRbac_authorization_k8s_ioV1beta1WatchNamespaces
+           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindings
+           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1beta1WatchClusterrolebindings
+           'clusterroles': ApisRbac_authorization_k8s_ioV1beta1WatchClusterroles
+           'clusterrole': ApisRbac_authorization_k8s_ioV1beta1WatchClusterroles
+           'rolebindings': ApisRbac_authorization_k8s_ioV1beta1WatchRolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1beta1WatchRolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1beta1WatchRoles
+           'role': ApisRbac_authorization_k8s_ioV1beta1WatchRoles
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindingsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRoles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'rolebindings': ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRoles
+           'role': ApisRbac_authorization_k8s_ioV1beta1NamespacesNameRoles
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1Namespaces {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1NamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1ClusterrolebindingsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1Clusterrolebindings {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1ClusterrolebindingsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1ClusterrolesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1Clusterroles {
+           // Path templating
+           (name: string): ApisRbac_authorization_k8s_ioV1beta1ClusterrolesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1Rolebindings {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1Roles {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_ioV1beta1 {
+           // Path templating
+           // Sub-paths
+           'watch': ApisRbac_authorization_k8s_ioV1beta1Watch
+           'namespaces': ApisRbac_authorization_k8s_ioV1beta1Namespaces
+           'ns': ApisRbac_authorization_k8s_ioV1beta1Namespaces
+           'namespace': ApisRbac_authorization_k8s_ioV1beta1Namespaces
+           'clusterrolebindings': ApisRbac_authorization_k8s_ioV1beta1Clusterrolebindings
+           'clusterrolebinding': ApisRbac_authorization_k8s_ioV1beta1Clusterrolebindings
+           'clusterroles': ApisRbac_authorization_k8s_ioV1beta1Clusterroles
+           'clusterrole': ApisRbac_authorization_k8s_ioV1beta1Clusterroles
+           'rolebindings': ApisRbac_authorization_k8s_ioV1beta1Rolebindings
+           'rolebinding': ApisRbac_authorization_k8s_ioV1beta1Rolebindings
+           'roles': ApisRbac_authorization_k8s_ioV1beta1Roles
+           'role': ApisRbac_authorization_k8s_ioV1beta1Roles
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisRbac_authorization_k8s_io {
+           // Path templating
+           // Sub-paths
+           'v1': ApisRbac_authorization_k8s_ioV1
+           'v1alpha1': ApisRbac_authorization_k8s_ioV1alpha1
+           'v1beta1': ApisRbac_authorization_k8s_ioV1beta1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresetsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresets {
+           // Path templating
+           (name: string): ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresetsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1WatchNamespacesName {
+           // Path templating
+           // Sub-paths
+           'podpresets': ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresets
+           'podpreset': ApisSettings_k8s_ioV1alpha1WatchNamespacesNamePodpresets
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1WatchNamespaces {
+           // Path templating
+           (name: string): ApisSettings_k8s_ioV1alpha1WatchNamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1WatchPodpresets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1Watch {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisSettings_k8s_ioV1alpha1WatchNamespaces
+           'ns': ApisSettings_k8s_ioV1alpha1WatchNamespaces
+           'namespace': ApisSettings_k8s_ioV1alpha1WatchNamespaces
+           'podpresets': ApisSettings_k8s_ioV1alpha1WatchPodpresets
+           'podpreset': ApisSettings_k8s_ioV1alpha1WatchPodpresets
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresetsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresets {
+           // Path templating
+           (name: string): ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresetsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'podpresets': ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresets
+           'podpreset': ApisSettings_k8s_ioV1alpha1NamespacesNamePodpresets
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1Namespaces {
+           // Path templating
+           (name: string): ApisSettings_k8s_ioV1alpha1NamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1Podpresets {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_ioV1alpha1 {
+           // Path templating
+           // Sub-paths
+           'watch': ApisSettings_k8s_ioV1alpha1Watch
+           'namespaces': ApisSettings_k8s_ioV1alpha1Namespaces
+           'ns': ApisSettings_k8s_ioV1alpha1Namespaces
+           'namespace': ApisSettings_k8s_ioV1alpha1Namespaces
+           'podpresets': ApisSettings_k8s_ioV1alpha1Podpresets
+           'podpreset': ApisSettings_k8s_ioV1alpha1Podpresets
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisSettings_k8s_io {
+           // Path templating
+           // Sub-paths
+           'v1alpha1': ApisSettings_k8s_ioV1alpha1
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
@@ -5384,6 +5883,476 @@ export interface ApisAdmissionregistration_k8s_io {
            addCustomResourceDefinition(schema: object): void
        }
 
+export interface ApisApiextensions_k8s_ioV1beta1CustomresourcedefinitionsNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiextensions_k8s_ioV1beta1CustomresourcedefinitionsName {
+           // Path templating
+           // Sub-paths
+           'status': ApisApiextensions_k8s_ioV1beta1CustomresourcedefinitionsNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiextensions_k8s_ioV1beta1Customresourcedefinitions {
+           // Path templating
+           (name: string): ApisApiextensions_k8s_ioV1beta1CustomresourcedefinitionsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitionsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitions {
+           // Path templating
+           (name: string): ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitionsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiextensions_k8s_ioV1beta1Watch {
+           // Path templating
+           // Sub-paths
+           'customresourcedefinitions': ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitions
+           'crd': ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitions
+           'customresourcedefinition': ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitions
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiextensions_k8s_ioV1beta1 {
+           // Path templating
+           // Sub-paths
+           'customresourcedefinitions': ApisApiextensions_k8s_ioV1beta1Customresourcedefinitions
+           'crd': ApisApiextensions_k8s_ioV1beta1Customresourcedefinitions
+           'customresourcedefinition': ApisApiextensions_k8s_ioV1beta1Customresourcedefinitions
+           'watch': ApisApiextensions_k8s_ioV1beta1Watch
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiextensions_k8s_io {
+           // Path templating
+           // Sub-paths
+           'v1beta1': ApisApiextensions_k8s_ioV1beta1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1ApiservicesNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1ApiservicesName {
+           // Path templating
+           // Sub-paths
+           'status': ApisApiregistration_k8s_ioV1ApiservicesNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1Apiservices {
+           // Path templating
+           (name: string): ApisApiregistration_k8s_ioV1ApiservicesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1WatchApiservicesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1WatchApiservices {
+           // Path templating
+           (name: string): ApisApiregistration_k8s_ioV1WatchApiservicesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1Watch {
+           // Path templating
+           // Sub-paths
+           'apiservices': ApisApiregistration_k8s_ioV1WatchApiservices
+           'apiservice': ApisApiregistration_k8s_ioV1WatchApiservices
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1 {
+           // Path templating
+           // Sub-paths
+           'apiservices': ApisApiregistration_k8s_ioV1Apiservices
+           'apiservice': ApisApiregistration_k8s_ioV1Apiservices
+           'watch': ApisApiregistration_k8s_ioV1Watch
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1beta1ApiservicesNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1beta1ApiservicesName {
+           // Path templating
+           // Sub-paths
+           'status': ApisApiregistration_k8s_ioV1beta1ApiservicesNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1beta1Apiservices {
+           // Path templating
+           (name: string): ApisApiregistration_k8s_ioV1beta1ApiservicesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1beta1WatchApiservicesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1beta1WatchApiservices {
+           // Path templating
+           (name: string): ApisApiregistration_k8s_ioV1beta1WatchApiservicesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1beta1Watch {
+           // Path templating
+           // Sub-paths
+           'apiservices': ApisApiregistration_k8s_ioV1beta1WatchApiservices
+           'apiservice': ApisApiregistration_k8s_ioV1beta1WatchApiservices
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_ioV1beta1 {
+           // Path templating
+           // Sub-paths
+           'apiservices': ApisApiregistration_k8s_ioV1beta1Apiservices
+           'apiservice': ApisApiregistration_k8s_ioV1beta1Apiservices
+           'watch': ApisApiregistration_k8s_ioV1beta1Watch
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisApiregistration_k8s_io {
+           // Path templating
+           // Sub-paths
+           'v1': ApisApiregistration_k8s_ioV1
+           'v1beta1': ApisApiregistration_k8s_ioV1beta1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinksName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinks {
+           // Path templating
+           (name: string): ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinksName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuditregistration_k8s_ioV1alpha1Watch {
+           // Path templating
+           // Sub-paths
+           'auditsinks': ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinks
+           'auditsink': ApisAuditregistration_k8s_ioV1alpha1WatchAuditsinks
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuditregistration_k8s_ioV1alpha1AuditsinksName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuditregistration_k8s_ioV1alpha1Auditsinks {
+           // Path templating
+           (name: string): ApisAuditregistration_k8s_ioV1alpha1AuditsinksName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuditregistration_k8s_ioV1alpha1 {
+           // Path templating
+           // Sub-paths
+           'watch': ApisAuditregistration_k8s_ioV1alpha1Watch
+           'auditsinks': ApisAuditregistration_k8s_ioV1alpha1Auditsinks
+           'auditsink': ApisAuditregistration_k8s_ioV1alpha1Auditsinks
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuditregistration_k8s_io {
+           // Path templating
+           // Sub-paths
+           'v1alpha1': ApisAuditregistration_k8s_ioV1alpha1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1NamespacesNameLocalsubjectaccessreviews {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'localsubjectaccessreviews': ApisAuthorization_k8s_ioV1NamespacesNameLocalsubjectaccessreviews
+           'localsubjectaccessreview': ApisAuthorization_k8s_ioV1NamespacesNameLocalsubjectaccessreviews
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1Namespaces {
+           // Path templating
+           (name: string): ApisAuthorization_k8s_ioV1NamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1Selfsubjectaccessreviews {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1Selfsubjectrulesreviews {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1Subjectaccessreviews {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1 {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisAuthorization_k8s_ioV1Namespaces
+           'ns': ApisAuthorization_k8s_ioV1Namespaces
+           'namespace': ApisAuthorization_k8s_ioV1Namespaces
+           'selfsubjectaccessreviews': ApisAuthorization_k8s_ioV1Selfsubjectaccessreviews
+           'selfsubjectaccessreview': ApisAuthorization_k8s_ioV1Selfsubjectaccessreviews
+           'selfsubjectrulesreviews': ApisAuthorization_k8s_ioV1Selfsubjectrulesreviews
+           'selfsubjectrulesreview': ApisAuthorization_k8s_ioV1Selfsubjectrulesreviews
+           'subjectaccessreviews': ApisAuthorization_k8s_ioV1Subjectaccessreviews
+           'subjectaccessreview': ApisAuthorization_k8s_ioV1Subjectaccessreviews
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1beta1NamespacesNameLocalsubjectaccessreviews {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1beta1NamespacesName {
+           // Path templating
+           // Sub-paths
+           'localsubjectaccessreviews': ApisAuthorization_k8s_ioV1beta1NamespacesNameLocalsubjectaccessreviews
+           'localsubjectaccessreview': ApisAuthorization_k8s_ioV1beta1NamespacesNameLocalsubjectaccessreviews
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1beta1Namespaces {
+           // Path templating
+           (name: string): ApisAuthorization_k8s_ioV1beta1NamespacesName
+           // Sub-paths
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1beta1Selfsubjectaccessreviews {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1beta1Selfsubjectrulesreviews {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1beta1Subjectaccessreviews {
+           // Path templating
+           // Sub-paths
+           // Calls
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_ioV1beta1 {
+           // Path templating
+           // Sub-paths
+           'namespaces': ApisAuthorization_k8s_ioV1beta1Namespaces
+           'ns': ApisAuthorization_k8s_ioV1beta1Namespaces
+           'namespace': ApisAuthorization_k8s_ioV1beta1Namespaces
+           'selfsubjectaccessreviews': ApisAuthorization_k8s_ioV1beta1Selfsubjectaccessreviews
+           'selfsubjectaccessreview': ApisAuthorization_k8s_ioV1beta1Selfsubjectaccessreviews
+           'selfsubjectrulesreviews': ApisAuthorization_k8s_ioV1beta1Selfsubjectrulesreviews
+           'selfsubjectrulesreview': ApisAuthorization_k8s_ioV1beta1Selfsubjectrulesreviews
+           'subjectaccessreviews': ApisAuthorization_k8s_ioV1beta1Subjectaccessreviews
+           'subjectaccessreview': ApisAuthorization_k8s_ioV1beta1Subjectaccessreviews
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisAuthorization_k8s_io {
+           // Path templating
+           // Sub-paths
+           'v1': ApisAuthorization_k8s_ioV1
+           'v1beta1': ApisAuthorization_k8s_ioV1beta1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
 export interface ApisCertificates_k8s_ioV1beta1CertificatesigningrequestsNameApproval {
            // Path templating
            // Sub-paths
@@ -5479,21 +6448,37 @@ export interface ApisCertificates_k8s_io {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiextensions_k8s_ioV1beta1CustomresourcedefinitionsNameStatus {
+export interface ApisScheduling_k8s_ioV1alpha1WatchPriorityclassesName {
            // Path templating
            // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiextensions_k8s_ioV1beta1CustomresourcedefinitionsName {
+export interface ApisScheduling_k8s_ioV1alpha1WatchPriorityclasses {
+           // Path templating
+           (name: string): ApisScheduling_k8s_ioV1alpha1WatchPriorityclassesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisScheduling_k8s_ioV1alpha1Watch {
            // Path templating
            // Sub-paths
-           'status': ApisApiextensions_k8s_ioV1beta1CustomresourcedefinitionsNameStatus
+           'priorityclasses': ApisScheduling_k8s_ioV1alpha1WatchPriorityclasses
+           'priorityclasse': ApisScheduling_k8s_ioV1alpha1WatchPriorityclasses
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisScheduling_k8s_ioV1alpha1PriorityclassesName {
+           // Path templating
+           // Sub-paths
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
@@ -5503,9 +6488,9 @@ export interface ApisApiextensions_k8s_ioV1beta1CustomresourcedefinitionsName {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiextensions_k8s_ioV1beta1Customresourcedefinitions {
+export interface ApisScheduling_k8s_ioV1alpha1Priorityclasses {
            // Path templating
-           (name: string): ApisApiextensions_k8s_ioV1beta1CustomresourcedefinitionsName
+           (name: string): ApisScheduling_k8s_ioV1alpha1PriorityclassesName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -5515,7 +6500,19 @@ export interface ApisApiextensions_k8s_ioV1beta1Customresourcedefinitions {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitionsName {
+export interface ApisScheduling_k8s_ioV1alpha1 {
+           // Path templating
+           // Sub-paths
+           'watch': ApisScheduling_k8s_ioV1alpha1Watch
+           'priorityclasses': ApisScheduling_k8s_ioV1alpha1Priorityclasses
+           'priorityclasse': ApisScheduling_k8s_ioV1alpha1Priorityclasses
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisScheduling_k8s_ioV1beta1WatchPriorityclassesName {
            // Path templating
            // Sub-paths
            // Calls
@@ -5524,9 +6521,9 @@ export interface ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitionsNa
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitions {
+export interface ApisScheduling_k8s_ioV1beta1WatchPriorityclasses {
            // Path templating
-           (name: string): ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitionsName
+           (name: string): ApisScheduling_k8s_ioV1beta1WatchPriorityclassesName
            // Sub-paths
            // Calls
            get(options ?: any): any
@@ -5534,33 +6531,366 @@ export interface ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitions {
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiextensions_k8s_ioV1beta1Watch {
+export interface ApisScheduling_k8s_ioV1beta1Watch {
            // Path templating
            // Sub-paths
-           'customresourcedefinitions': ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitions
-           'crd': ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitions
-           'customresourcedefinition': ApisApiextensions_k8s_ioV1beta1WatchCustomresourcedefinitions
+           'priorityclasses': ApisScheduling_k8s_ioV1beta1WatchPriorityclasses
+           'priorityclasse': ApisScheduling_k8s_ioV1beta1WatchPriorityclasses
            // Calls
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiextensions_k8s_ioV1beta1 {
+export interface ApisScheduling_k8s_ioV1beta1PriorityclassesName {
            // Path templating
            // Sub-paths
-           'customresourcedefinitions': ApisApiextensions_k8s_ioV1beta1Customresourcedefinitions
-           'crd': ApisApiextensions_k8s_ioV1beta1Customresourcedefinitions
-           'customresourcedefinition': ApisApiextensions_k8s_ioV1beta1Customresourcedefinitions
-           'watch': ApisApiextensions_k8s_ioV1beta1Watch
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisScheduling_k8s_ioV1beta1Priorityclasses {
+           // Path templating
+           (name: string): ApisScheduling_k8s_ioV1beta1PriorityclassesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisScheduling_k8s_ioV1beta1 {
+           // Path templating
+           // Sub-paths
+           'watch': ApisScheduling_k8s_ioV1beta1Watch
+           'priorityclasses': ApisScheduling_k8s_ioV1beta1Priorityclasses
+           'priorityclasse': ApisScheduling_k8s_ioV1beta1Priorityclasses
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
            addCustomResourceDefinition(schema: object): void
        }
 
-export interface ApisApiextensions_k8s_io {
+export interface ApisScheduling_k8s_io {
            // Path templating
            // Sub-paths
-           'v1beta1': ApisApiextensions_k8s_ioV1beta1
+           'v1alpha1': ApisScheduling_k8s_ioV1alpha1
+           'v1beta1': ApisScheduling_k8s_ioV1beta1
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1VolumeattachmentsNameStatus {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1VolumeattachmentsName {
+           // Path templating
+           // Sub-paths
+           'status': ApisStorage_k8s_ioV1VolumeattachmentsNameStatus
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1Volumeattachments {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1VolumeattachmentsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1WatchStorageclassesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1WatchStorageclasses {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1WatchStorageclassesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1WatchVolumeattachmentsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1WatchVolumeattachments {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1WatchVolumeattachmentsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1Watch {
+           // Path templating
+           // Sub-paths
+           'storageclasses': ApisStorage_k8s_ioV1WatchStorageclasses
+           'storageclasse': ApisStorage_k8s_ioV1WatchStorageclasses
+           'volumeattachments': ApisStorage_k8s_ioV1WatchVolumeattachments
+           'volumeattachment': ApisStorage_k8s_ioV1WatchVolumeattachments
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1StorageclassesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1Storageclasses {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1StorageclassesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1 {
+           // Path templating
+           // Sub-paths
+           'volumeattachments': ApisStorage_k8s_ioV1Volumeattachments
+           'volumeattachment': ApisStorage_k8s_ioV1Volumeattachments
+           'watch': ApisStorage_k8s_ioV1Watch
+           'storageclasses': ApisStorage_k8s_ioV1Storageclasses
+           'storageclasse': ApisStorage_k8s_ioV1Storageclasses
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1alpha1WatchVolumeattachmentsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1alpha1WatchVolumeattachments {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1alpha1WatchVolumeattachmentsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1alpha1Watch {
+           // Path templating
+           // Sub-paths
+           'volumeattachments': ApisStorage_k8s_ioV1alpha1WatchVolumeattachments
+           'volumeattachment': ApisStorage_k8s_ioV1alpha1WatchVolumeattachments
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1alpha1VolumeattachmentsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1alpha1Volumeattachments {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1alpha1VolumeattachmentsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1alpha1 {
+           // Path templating
+           // Sub-paths
+           'watch': ApisStorage_k8s_ioV1alpha1Watch
+           'volumeattachments': ApisStorage_k8s_ioV1alpha1Volumeattachments
+           'volumeattachment': ApisStorage_k8s_ioV1alpha1Volumeattachments
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1WatchStorageclassesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1WatchStorageclasses {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1beta1WatchStorageclassesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1WatchVolumeattachmentsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1WatchVolumeattachments {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1beta1WatchVolumeattachmentsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1Watch {
+           // Path templating
+           // Sub-paths
+           'storageclasses': ApisStorage_k8s_ioV1beta1WatchStorageclasses
+           'storageclasse': ApisStorage_k8s_ioV1beta1WatchStorageclasses
+           'volumeattachments': ApisStorage_k8s_ioV1beta1WatchVolumeattachments
+           'volumeattachment': ApisStorage_k8s_ioV1beta1WatchVolumeattachments
+           // Calls
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1StorageclassesName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1Storageclasses {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1beta1StorageclassesName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1VolumeattachmentsName {
+           // Path templating
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           patch(options ?: any): any
+           put(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1Volumeattachments {
+           // Path templating
+           (name: string): ApisStorage_k8s_ioV1beta1VolumeattachmentsName
+           // Sub-paths
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           delete(options ?: any): any
+           post(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_ioV1beta1 {
+           // Path templating
+           // Sub-paths
+           'watch': ApisStorage_k8s_ioV1beta1Watch
+           'storageclasses': ApisStorage_k8s_ioV1beta1Storageclasses
+           'storageclasse': ApisStorage_k8s_ioV1beta1Storageclasses
+           'volumeattachments': ApisStorage_k8s_ioV1beta1Volumeattachments
+           'volumeattachment': ApisStorage_k8s_ioV1beta1Volumeattachments
+           // Calls
+           get(options ?: any): any
+           getStream(options ?: any): any
+           addCustomResourceDefinition(schema: object): void
+       }
+
+export interface ApisStorage_k8s_io {
+           // Path templating
+           // Sub-paths
+           'v1': ApisStorage_k8s_ioV1
+           'v1alpha1': ApisStorage_k8s_ioV1alpha1
+           'v1beta1': ApisStorage_k8s_ioV1beta1
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
@@ -5621,1355 +6951,25 @@ export interface Apis {
            // Sub-paths
            'apps': ApisApps
            'app': ApisApps
-           'settings.k8s.io': ApisSettings_k8s_io
-           'rbac.authorization.k8s.io': ApisRbac_authorization_k8s_io
-           'policy': ApisPolicy
-           'networking.k8s.io': ApisNetworking_k8s_io
-           'extensions': ApisExtensions
-           'extension': ApisExtensions
            'autoscaling': ApisAutoscaling
            'batch': ApisBatch
-           'events.k8s.io': ApisEvents_k8s_io
            'coordination.k8s.io': ApisCoordination_k8s_io
-           'apiregistration.k8s.io': ApisApiregistration_k8s_io
-           'storage.k8s.io': ApisStorage_k8s_io
-           'auditregistration.k8s.io': ApisAuditregistration_k8s_io
-           'scheduling.k8s.io': ApisScheduling_k8s_io
-           'authorization.k8s.io': ApisAuthorization_k8s_io
+           'events.k8s.io': ApisEvents_k8s_io
+           'extensions': ApisExtensions
+           'extension': ApisExtensions
+           'networking.k8s.io': ApisNetworking_k8s_io
+           'policy': ApisPolicy
+           'rbac.authorization.k8s.io': ApisRbac_authorization_k8s_io
+           'settings.k8s.io': ApisSettings_k8s_io
            'admissionregistration.k8s.io': ApisAdmissionregistration_k8s_io
-           'certificates.k8s.io': ApisCertificates_k8s_io
            'apiextensions.k8s.io': ApisApiextensions_k8s_io
+           'apiregistration.k8s.io': ApisApiregistration_k8s_io
+           'auditregistration.k8s.io': ApisAuditregistration_k8s_io
+           'authorization.k8s.io': ApisAuthorization_k8s_io
+           'certificates.k8s.io': ApisCertificates_k8s_io
+           'scheduling.k8s.io': ApisScheduling_k8s_io
+           'storage.k8s.io': ApisStorage_k8s_io
            'authentication.k8s.io': ApisAuthentication_k8s_io
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsNameProxyName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           post(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsNameProxy {
-           // Path templating
-           (name: string): ApiV1NamespacesNamePodsNameProxyName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           post(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsNameAttach {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsNameBinding {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsNameEviction {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsNameExec {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsNameLog {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsNamePortforward {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodsName {
-           // Path templating
-           // Sub-paths
-           'proxy': ApiV1NamespacesNamePodsNameProxy
-           'attach': ApiV1NamespacesNamePodsNameAttach
-           'binding': ApiV1NamespacesNamePodsNameBinding
-           'eviction': ApiV1NamespacesNamePodsNameEviction
-           'exec': ApiV1NamespacesNamePodsNameExec
-           'log': ApiV1NamespacesNamePodsNameLog
-           'portforward': ApiV1NamespacesNamePodsNamePortforward
-           'status': ApiV1NamespacesNamePodsNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePods {
-           // Path templating
-           (name: string): ApiV1NamespacesNamePodsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameServicesNameProxyName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           post(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameServicesNameProxy {
-           // Path templating
-           (name: string): ApiV1NamespacesNameServicesNameProxyName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           post(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameServicesNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameServicesName {
-           // Path templating
-           // Sub-paths
-           'proxy': ApiV1NamespacesNameServicesNameProxy
-           'status': ApiV1NamespacesNameServicesNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameServices {
-           // Path templating
-           (name: string): ApiV1NamespacesNameServicesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePersistentvolumeclaimsNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePersistentvolumeclaimsName {
-           // Path templating
-           // Sub-paths
-           'status': ApiV1NamespacesNamePersistentvolumeclaimsNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePersistentvolumeclaims {
-           // Path templating
-           (name: string): ApiV1NamespacesNamePersistentvolumeclaimsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameReplicationcontrollersNameScale {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameReplicationcontrollersNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameReplicationcontrollersName {
-           // Path templating
-           // Sub-paths
-           'scale': ApiV1NamespacesNameReplicationcontrollersNameScale
-           'status': ApiV1NamespacesNameReplicationcontrollersNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameReplicationcontrollers {
-           // Path templating
-           (name: string): ApiV1NamespacesNameReplicationcontrollersName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameResourcequotasNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameResourcequotasName {
-           // Path templating
-           // Sub-paths
-           'status': ApiV1NamespacesNameResourcequotasNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameResourcequotas {
-           // Path templating
-           (name: string): ApiV1NamespacesNameResourcequotasName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodtemplatesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNamePodtemplates {
-           // Path templating
-           (name: string): ApiV1NamespacesNamePodtemplatesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameConfigmapsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameConfigmaps {
-           // Path templating
-           (name: string): ApiV1NamespacesNameConfigmapsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameEndpointsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameEndpoints {
-           // Path templating
-           (name: string): ApiV1NamespacesNameEndpointsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameSecretsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameSecrets {
-           // Path templating
-           (name: string): ApiV1NamespacesNameSecretsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameServiceaccountsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameServiceaccounts {
-           // Path templating
-           (name: string): ApiV1NamespacesNameServiceaccountsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameEventsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameEvents {
-           // Path templating
-           (name: string): ApiV1NamespacesNameEventsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameLimitrangesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameLimitranges {
-           // Path templating
-           (name: string): ApiV1NamespacesNameLimitrangesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameFinalize {
-           // Path templating
-           // Sub-paths
-           // Calls
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesNameBindings {
-           // Path templating
-           // Sub-paths
-           // Calls
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NamespacesName {
-           // Path templating
-           // Sub-paths
-           'pods': ApiV1NamespacesNamePods
-           'po': ApiV1NamespacesNamePods
-           'pod': ApiV1NamespacesNamePods
-           'services': ApiV1NamespacesNameServices
-           'svc': ApiV1NamespacesNameServices
-           'service': ApiV1NamespacesNameServices
-           'persistentvolumeclaims': ApiV1NamespacesNamePersistentvolumeclaims
-           'pvc': ApiV1NamespacesNamePersistentvolumeclaims
-           'persistentvolumeclaim': ApiV1NamespacesNamePersistentvolumeclaims
-           'replicationcontrollers': ApiV1NamespacesNameReplicationcontrollers
-           'rc': ApiV1NamespacesNameReplicationcontrollers
-           'replicationcontroller': ApiV1NamespacesNameReplicationcontrollers
-           'resourcequotas': ApiV1NamespacesNameResourcequotas
-           'quota': ApiV1NamespacesNameResourcequotas
-           'resourcequota': ApiV1NamespacesNameResourcequotas
-           'podtemplates': ApiV1NamespacesNamePodtemplates
-           'podtemplate': ApiV1NamespacesNamePodtemplates
-           'configmaps': ApiV1NamespacesNameConfigmaps
-           'cm': ApiV1NamespacesNameConfigmaps
-           'configmap': ApiV1NamespacesNameConfigmaps
-           'endpoints': ApiV1NamespacesNameEndpoints
-           'ep': ApiV1NamespacesNameEndpoints
-           'endpoint': ApiV1NamespacesNameEndpoints
-           'secrets': ApiV1NamespacesNameSecrets
-           'secret': ApiV1NamespacesNameSecrets
-           'serviceaccounts': ApiV1NamespacesNameServiceaccounts
-           'serviceaccount': ApiV1NamespacesNameServiceaccounts
-           'events': ApiV1NamespacesNameEvents
-           'ev': ApiV1NamespacesNameEvents
-           'event': ApiV1NamespacesNameEvents
-           'limitranges': ApiV1NamespacesNameLimitranges
-           'limits': ApiV1NamespacesNameLimitranges
-           'limitrange': ApiV1NamespacesNameLimitranges
-           'status': ApiV1NamespacesNameStatus
-           'finalize': ApiV1NamespacesNameFinalize
-           'bindings': ApiV1NamespacesNameBindings
-           'binding': ApiV1NamespacesNameBindings
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Namespaces {
-           // Path templating
-           (name: string): ApiV1NamespacesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameConfigmapsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameConfigmaps {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNameConfigmapsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameEndpointsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameEndpoints {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNameEndpointsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameEventsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameEvents {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNameEventsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameLimitrangesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameLimitranges {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNameLimitrangesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNamePersistentvolumeclaimsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNamePersistentvolumeclaims {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNamePersistentvolumeclaimsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNamePodsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNamePods {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNamePodsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNamePodtemplatesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNamePodtemplates {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNamePodtemplatesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameReplicationcontrollersName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameReplicationcontrollers {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNameReplicationcontrollersName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameResourcequotasName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameResourcequotas {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNameResourcequotasName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameSecretsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameSecrets {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNameSecretsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameServiceaccountsName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameServiceaccounts {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNameServiceaccountsName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameServicesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesNameServices {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesNameServicesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespacesName {
-           // Path templating
-           // Sub-paths
-           'configmaps': ApiV1WatchNamespacesNameConfigmaps
-           'cm': ApiV1WatchNamespacesNameConfigmaps
-           'configmap': ApiV1WatchNamespacesNameConfigmaps
-           'endpoints': ApiV1WatchNamespacesNameEndpoints
-           'ep': ApiV1WatchNamespacesNameEndpoints
-           'endpoint': ApiV1WatchNamespacesNameEndpoints
-           'events': ApiV1WatchNamespacesNameEvents
-           'ev': ApiV1WatchNamespacesNameEvents
-           'event': ApiV1WatchNamespacesNameEvents
-           'limitranges': ApiV1WatchNamespacesNameLimitranges
-           'limits': ApiV1WatchNamespacesNameLimitranges
-           'limitrange': ApiV1WatchNamespacesNameLimitranges
-           'persistentvolumeclaims': ApiV1WatchNamespacesNamePersistentvolumeclaims
-           'pvc': ApiV1WatchNamespacesNamePersistentvolumeclaims
-           'persistentvolumeclaim': ApiV1WatchNamespacesNamePersistentvolumeclaims
-           'pods': ApiV1WatchNamespacesNamePods
-           'po': ApiV1WatchNamespacesNamePods
-           'pod': ApiV1WatchNamespacesNamePods
-           'podtemplates': ApiV1WatchNamespacesNamePodtemplates
-           'podtemplate': ApiV1WatchNamespacesNamePodtemplates
-           'replicationcontrollers': ApiV1WatchNamespacesNameReplicationcontrollers
-           'rc': ApiV1WatchNamespacesNameReplicationcontrollers
-           'replicationcontroller': ApiV1WatchNamespacesNameReplicationcontrollers
-           'resourcequotas': ApiV1WatchNamespacesNameResourcequotas
-           'quota': ApiV1WatchNamespacesNameResourcequotas
-           'resourcequota': ApiV1WatchNamespacesNameResourcequotas
-           'secrets': ApiV1WatchNamespacesNameSecrets
-           'secret': ApiV1WatchNamespacesNameSecrets
-           'serviceaccounts': ApiV1WatchNamespacesNameServiceaccounts
-           'serviceaccount': ApiV1WatchNamespacesNameServiceaccounts
-           'services': ApiV1WatchNamespacesNameServices
-           'svc': ApiV1WatchNamespacesNameServices
-           'service': ApiV1WatchNamespacesNameServices
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNamespaces {
-           // Path templating
-           (name: string): ApiV1WatchNamespacesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchPersistentvolumesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchPersistentvolumes {
-           // Path templating
-           (name: string): ApiV1WatchPersistentvolumesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNodesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchNodes {
-           // Path templating
-           (name: string): ApiV1WatchNodesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchLimitranges {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchPersistentvolumeclaims {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchPods {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchPodtemplates {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchReplicationcontrollers {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchResourcequotas {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchSecrets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchServiceaccounts {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchServices {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchConfigmaps {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchEndpoints {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1WatchEvents {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Watch {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApiV1WatchNamespaces
-           'ns': ApiV1WatchNamespaces
-           'namespace': ApiV1WatchNamespaces
-           'persistentvolumes': ApiV1WatchPersistentvolumes
-           'pv': ApiV1WatchPersistentvolumes
-           'persistentvolume': ApiV1WatchPersistentvolumes
-           'nodes': ApiV1WatchNodes
-           'no': ApiV1WatchNodes
-           'node': ApiV1WatchNodes
-           'limitranges': ApiV1WatchLimitranges
-           'limits': ApiV1WatchLimitranges
-           'limitrange': ApiV1WatchLimitranges
-           'persistentvolumeclaims': ApiV1WatchPersistentvolumeclaims
-           'pvc': ApiV1WatchPersistentvolumeclaims
-           'persistentvolumeclaim': ApiV1WatchPersistentvolumeclaims
-           'pods': ApiV1WatchPods
-           'po': ApiV1WatchPods
-           'pod': ApiV1WatchPods
-           'podtemplates': ApiV1WatchPodtemplates
-           'podtemplate': ApiV1WatchPodtemplates
-           'replicationcontrollers': ApiV1WatchReplicationcontrollers
-           'rc': ApiV1WatchReplicationcontrollers
-           'replicationcontroller': ApiV1WatchReplicationcontrollers
-           'resourcequotas': ApiV1WatchResourcequotas
-           'quota': ApiV1WatchResourcequotas
-           'resourcequota': ApiV1WatchResourcequotas
-           'secrets': ApiV1WatchSecrets
-           'secret': ApiV1WatchSecrets
-           'serviceaccounts': ApiV1WatchServiceaccounts
-           'serviceaccount': ApiV1WatchServiceaccounts
-           'services': ApiV1WatchServices
-           'svc': ApiV1WatchServices
-           'service': ApiV1WatchServices
-           'configmaps': ApiV1WatchConfigmaps
-           'cm': ApiV1WatchConfigmaps
-           'configmap': ApiV1WatchConfigmaps
-           'endpoints': ApiV1WatchEndpoints
-           'ep': ApiV1WatchEndpoints
-           'endpoint': ApiV1WatchEndpoints
-           'events': ApiV1WatchEvents
-           'ev': ApiV1WatchEvents
-           'event': ApiV1WatchEvents
-           // Calls
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NodesNameProxyName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           post(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NodesNameProxy {
-           // Path templating
-           (name: string): ApiV1NodesNameProxyName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           post(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NodesNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1NodesName {
-           // Path templating
-           // Sub-paths
-           'proxy': ApiV1NodesNameProxy
-           'status': ApiV1NodesNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Nodes {
-           // Path templating
-           (name: string): ApiV1NodesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1PersistentvolumesNameStatus {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1PersistentvolumesName {
-           // Path templating
-           // Sub-paths
-           'status': ApiV1PersistentvolumesNameStatus
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           patch(options ?: any): any
-           put(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Persistentvolumes {
-           // Path templating
-           (name: string): ApiV1PersistentvolumesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           delete(options ?: any): any
-           post(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1ComponentstatusesName {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Componentstatuses {
-           // Path templating
-           (name: string): ApiV1ComponentstatusesName
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Services {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Serviceaccounts {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Secrets {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Resourcequotas {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Replicationcontrollers {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Podtemplates {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Pods {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Persistentvolumeclaims {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Limitranges {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Events {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Endpoints {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1Configmaps {
-           // Path templating
-           // Sub-paths
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface ApiV1 {
-           // Path templating
-           // Sub-paths
-           'namespaces': ApiV1Namespaces
-           'ns': ApiV1Namespaces
-           'namespace': ApiV1Namespaces
-           'watch': ApiV1Watch
-           'nodes': ApiV1Nodes
-           'no': ApiV1Nodes
-           'node': ApiV1Nodes
-           'persistentvolumes': ApiV1Persistentvolumes
-           'pv': ApiV1Persistentvolumes
-           'persistentvolume': ApiV1Persistentvolumes
-           'componentstatuses': ApiV1Componentstatuses
-           'cs': ApiV1Componentstatuses
-           'componentstatus': ApiV1Componentstatuses
-           'services': ApiV1Services
-           'svc': ApiV1Services
-           'service': ApiV1Services
-           'serviceaccounts': ApiV1Serviceaccounts
-           'serviceaccount': ApiV1Serviceaccounts
-           'secrets': ApiV1Secrets
-           'secret': ApiV1Secrets
-           'resourcequotas': ApiV1Resourcequotas
-           'quota': ApiV1Resourcequotas
-           'resourcequota': ApiV1Resourcequotas
-           'replicationcontrollers': ApiV1Replicationcontrollers
-           'rc': ApiV1Replicationcontrollers
-           'replicationcontroller': ApiV1Replicationcontrollers
-           'podtemplates': ApiV1Podtemplates
-           'podtemplate': ApiV1Podtemplates
-           'pods': ApiV1Pods
-           'po': ApiV1Pods
-           'pod': ApiV1Pods
-           'persistentvolumeclaims': ApiV1Persistentvolumeclaims
-           'pvc': ApiV1Persistentvolumeclaims
-           'persistentvolumeclaim': ApiV1Persistentvolumeclaims
-           'limitranges': ApiV1Limitranges
-           'limits': ApiV1Limitranges
-           'limitrange': ApiV1Limitranges
-           'events': ApiV1Events
-           'ev': ApiV1Events
-           'event': ApiV1Events
-           'endpoints': ApiV1Endpoints
-           'ep': ApiV1Endpoints
-           'endpoint': ApiV1Endpoints
-           'configmaps': ApiV1Configmaps
-           'cm': ApiV1Configmaps
-           'configmap': ApiV1Configmaps
-           // Calls
-           get(options ?: any): any
-           getStream(options ?: any): any
-           addCustomResourceDefinition(schema: object): void
-       }
-
-export interface Api {
-           // Path templating
-           // Sub-paths
-           'v1': ApiV1
            // Calls
            get(options ?: any): any
            getStream(options ?: any): any
@@ -7007,8 +7007,8 @@ export interface Version {
 export interface ApiRoot {
            // Path templating
            // Sub-paths
-           'apis': Apis
            'api': Api
+           'apis': Apis
            'logs': Logs
            'log': Logs
            'version': Version


### PR DESCRIPTION
This is a follow up to https://github.com/godaddy/kubernetes-client/pull/528#issuecomment-579661176. I'm hoping to update openid-client in order to resolve a deprecation warning:

```
(node:81223) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
```

This originates from `timed-out`:

```
kubernetes-client@8.3.6 /Users/ben/src/godaddy/kubernetes-client
└─┬ openid-client@2.5.0
  └─┬ got@8.3.2
    └── timed-out@4.0.1
```

Later versions upgrade `got` and in turn `timed-out`.

Because this change eliminates node 8 compatibility, it should be released as breaking (v9). 