### PR TITLE
Allow OIDC clock skew of up to 10s

### DIFF
--- a/backends/request/auth-providers/openid.js
+++ b/backends/request/auth-providers/openid.js
@@ -4,6 +4,7 @@
 
 'use strict'
 
+const { custom } = require('openid-client')
 const Issuer = require('openid-client').Issuer
 
 module.exports = {
@@ -15,6 +16,8 @@ module.exports = {
             client_id: config['client-id'],
             client_secret: config['client-secret']
           })
+          
+          client[custom.clock_tolerance] = 10
 
           return client.refresh(config['refresh-token'])
         })


### PR DESCRIPTION
Clock skew may cause an error about id_token issued in the future.
`openid-client` lib provides a tolerance to solve this. https://github.com/panva/node-openid-client/blob/master/docs/README.md#customizing-clock-skew-tolerance
